### PR TITLE
feat: Add game and players statistic collecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ content.xml
 *.pfx
 
 .github/copilot-instructions.md
+.github/COPILOT.md
 
 # Generated files
 **/*_generated.dart

--- a/server/src/application/Container.ts
+++ b/server/src/application/Container.ts
@@ -59,6 +59,7 @@ export const CONTAINER_TYPES = {
   SocketUserDataRepository: Symbol("SocketUserDataRepository"),
   RedisRepository: Symbol("RedisRepository"),
   SocketChatRepository: Symbol("SocketChatRepository"),
+  GameStatisticsRepository: Symbol("GameStatisticsRepository"),
 
   // Services
   UserService: Symbol("UserService"),
@@ -82,9 +83,14 @@ export const CONTAINER_TYPES = {
   SocketGameValidationService: Symbol("SocketGameValidationService"),
   SocketQuestionStateService: Symbol("SocketQuestionStateService"),
   UserNotificationRoomService: Symbol("UserNotificationRoomService"),
+  GameStatisticsCollectorService: Symbol("GameStatisticsCollectorService"),
+  GameStatisticsService: Symbol("GameStatisticsService"),
+  PlayerGameStatsService: Symbol("PlayerGameStatsService"),
+  PlayerGameStatsRepository: Symbol("PlayerGameStatsRepository"),
 
   // Factories
   RoundHandlerFactory: Symbol("RoundHandlerFactory"),
+  StatisticsWorkerFactory: Symbol("StatisticsWorkerFactory"),
 
   // Use cases
   UserCacheUseCase: Symbol("UserCacheUseCase"),

--- a/server/src/application/config/DIConfig.ts
+++ b/server/src/application/config/DIConfig.ts
@@ -199,10 +199,34 @@ export class DIConfig {
     );
 
     Container.register(
+      CONTAINER_TYPES.PlayerGameStatsRepository,
+      new PlayerGameStatsRepository(
+        db.getRepository(PlayerGameStats),
+        Container.get<RedisService>(CONTAINER_TYPES.RedisService),
+        this.logger
+      ),
+      "repository"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.PlayerGameStatsService,
+      new PlayerGameStatsService(
+        Container.get<PlayerGameStatsRepository>(
+          CONTAINER_TYPES.PlayerGameStatsRepository
+        ),
+        this.logger
+      ),
+      "service"
+    );
+
+    Container.register(
       CONTAINER_TYPES.StatisticsWorkerFactory,
       new StatisticsWorkerFactory(
         Container.get<GameStatisticsRepository>(
           CONTAINER_TYPES.GameStatisticsRepository
+        ),
+        Container.get<PlayerGameStatsService>(
+          CONTAINER_TYPES.PlayerGameStatsService
         ),
         this.logger
       ),
@@ -217,26 +241,6 @@ export class DIConfig {
         ),
         Container.get<StatisticsWorkerFactory>(
           CONTAINER_TYPES.StatisticsWorkerFactory
-        ),
-        this.logger
-      ),
-      "service"
-    );
-
-    Container.register(
-      CONTAINER_TYPES.PlayerGameStatsRepository,
-      new PlayerGameStatsRepository(
-        db.getRepository(PlayerGameStats),
-        Container.get<RedisService>(CONTAINER_TYPES.RedisService)
-      ),
-      "repository"
-    );
-
-    Container.register(
-      CONTAINER_TYPES.PlayerGameStatsService,
-      new PlayerGameStatsService(
-        Container.get<PlayerGameStatsRepository>(
-          CONTAINER_TYPES.PlayerGameStatsRepository
         ),
         this.logger
       ),
@@ -415,6 +419,9 @@ export class DIConfig {
           CONTAINER_TYPES.SocketGameTimerService
         ),
         Container.get<RoundHandlerFactory>(CONTAINER_TYPES.RoundHandlerFactory),
+        Container.get<PlayerGameStatsService>(
+          CONTAINER_TYPES.PlayerGameStatsService
+        ),
         this.logger
       ),
       "service"
@@ -457,6 +464,9 @@ export class DIConfig {
         Container.get<FinalRoundService>(CONTAINER_TYPES.FinalRoundService),
         Container.get<GameStatisticsCollectorService>(
           CONTAINER_TYPES.GameStatisticsCollectorService
+        ),
+        Container.get<PlayerGameStatsService>(
+          CONTAINER_TYPES.PlayerGameStatsService
         ),
         this.logger
       ),

--- a/server/src/application/config/DIConfig.ts
+++ b/server/src/application/config/DIConfig.ts
@@ -3,6 +3,7 @@ import { Server as IOServer } from "socket.io";
 
 import { Container, CONTAINER_TYPES } from "application/Container";
 import { StorageContextBuilder } from "application/context/storage/StorageContextBuilder";
+import { StatisticsWorkerFactory } from "application/factories/StatisticsWorkerFactory";
 import { GameExpirationHandler } from "application/handlers/GameExpirationHandler";
 import { TimerExpirationHandler } from "application/handlers/TimerExpirationHandler";
 import { FileService } from "application/services/file/FileService";
@@ -19,6 +20,9 @@ import { SocketIOGameService } from "application/services/socket/SocketIOGameSer
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
 import { SocketQuestionStateService } from "application/services/socket/SocketQuestionStateService";
 import { UserNotificationRoomService } from "application/services/socket/UserNotificationRoomService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
+import { GameStatisticsService } from "application/services/statistics/GameStatisticsService";
+import { PlayerGameStatsService } from "application/services/statistics/PlayerGameStatsService";
 import { TranslateService } from "application/services/text/TranslateService";
 import { UserService } from "application/services/user/UserService";
 import { UserCacheUseCase } from "application/usecases/user/UserCacheUseCase";
@@ -34,6 +38,8 @@ import { FileUsage } from "infrastructure/database/models/FileUsage";
 import { Package } from "infrastructure/database/models/package/Package";
 import { PackageTag } from "infrastructure/database/models/package/PackageTag";
 import { Permission } from "infrastructure/database/models/Permission";
+import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
+import { PlayerGameStats } from "infrastructure/database/models/statistics/PlayerGameStats";
 import { User } from "infrastructure/database/models/User";
 import { FileRepository } from "infrastructure/database/repositories/FileRepository";
 import { FileUsageRepository } from "infrastructure/database/repositories/FileUsageRepository";
@@ -44,6 +50,8 @@ import { PermissionRepository } from "infrastructure/database/repositories/Permi
 import { RedisRepository } from "infrastructure/database/repositories/RedisRepository";
 import { SocketChatRepository } from "infrastructure/database/repositories/socket/SocketChatRepository";
 import { SocketUserDataRepository } from "infrastructure/database/repositories/socket/SocketUserDataRepository";
+import { GameStatisticsRepository } from "infrastructure/database/repositories/statistics/GameStatisticsRepository";
+import { PlayerGameStatsRepository } from "infrastructure/database/repositories/statistics/PlayerGameStatsRepository";
 import { UserRepository } from "infrastructure/database/repositories/UserRepository";
 import { ILogger } from "infrastructure/logger/ILogger";
 import { DependencyService } from "infrastructure/services/dependency/DependencyService";
@@ -169,6 +177,70 @@ export class DIConfig {
         Container.get<RedisCache>(CONTAINER_TYPES.RedisCache)
       ),
       "useCase"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.GameStatisticsRepository,
+      new GameStatisticsRepository(
+        db.getRepository(GameStatistics),
+        Container.get<RedisService>(CONTAINER_TYPES.RedisService)
+      ),
+      "repository"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.GameStatisticsService,
+      new GameStatisticsService(
+        Container.get<GameStatisticsRepository>(
+          CONTAINER_TYPES.GameStatisticsRepository
+        )
+      ),
+      "service"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.StatisticsWorkerFactory,
+      new StatisticsWorkerFactory(
+        Container.get<GameStatisticsRepository>(
+          CONTAINER_TYPES.GameStatisticsRepository
+        ),
+        this.logger
+      ),
+      "service"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.GameStatisticsCollectorService,
+      new GameStatisticsCollectorService(
+        Container.get<GameStatisticsService>(
+          CONTAINER_TYPES.GameStatisticsService
+        ),
+        Container.get<StatisticsWorkerFactory>(
+          CONTAINER_TYPES.StatisticsWorkerFactory
+        ),
+        this.logger
+      ),
+      "service"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.PlayerGameStatsRepository,
+      new PlayerGameStatsRepository(
+        db.getRepository(PlayerGameStats),
+        Container.get<RedisService>(CONTAINER_TYPES.RedisService)
+      ),
+      "repository"
+    );
+
+    Container.register(
+      CONTAINER_TYPES.PlayerGameStatsService,
+      new PlayerGameStatsService(
+        Container.get<PlayerGameStatsRepository>(
+          CONTAINER_TYPES.PlayerGameStatsRepository
+        ),
+        this.logger
+      ),
+      "service"
     );
 
     Container.register(
@@ -383,6 +455,9 @@ export class DIConfig {
         ),
         Container.get<RoundHandlerFactory>(CONTAINER_TYPES.RoundHandlerFactory),
         Container.get<FinalRoundService>(CONTAINER_TYPES.FinalRoundService),
+        Container.get<GameStatisticsCollectorService>(
+          CONTAINER_TYPES.GameStatisticsCollectorService
+        ),
         this.logger
       ),
     ];
@@ -417,7 +492,14 @@ export class DIConfig {
         Container.get<RoundHandlerFactory>(CONTAINER_TYPES.RoundHandlerFactory),
         Container.get<SocketIOQuestionService>(
           CONTAINER_TYPES.SocketIOQuestionService
-        )
+        ),
+        Container.get<GameStatisticsCollectorService>(
+          CONTAINER_TYPES.GameStatisticsCollectorService
+        ),
+        Container.get<PlayerGameStatsService>(
+          CONTAINER_TYPES.PlayerGameStatsService
+        ),
+        this.logger
       ),
       "service"
     );

--- a/server/src/application/factories/StatisticsWorkerFactory.ts
+++ b/server/src/application/factories/StatisticsWorkerFactory.ts
@@ -1,0 +1,31 @@
+import { GameStatisticsPersistenceWorker } from "application/workers/GameStatisticsPersistenceWorker";
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+import { GameStatisticsRepository } from "infrastructure/database/repositories/statistics/GameStatisticsRepository";
+import { ILogger } from "infrastructure/logger/ILogger";
+
+export class StatisticsWorkerFactory {
+  constructor(
+    private readonly gameStatisticsRepository: GameStatisticsRepository,
+    private readonly logger: ILogger
+  ) {
+    //
+  }
+
+  public createGameStatisticsPersistenceWorker(): GameStatisticsPersistenceWorker {
+    return new GameStatisticsPersistenceWorker(
+      this.gameStatisticsRepository,
+      this.logger
+    );
+  }
+
+  /**
+   * Execute game statistics persistence workflow
+   * Convenience method for creating and executing worker in one call
+   */
+  public async executeGameStatisticsPersistence(
+    gameStats: GameStatisticsData
+  ): Promise<void> {
+    const worker = this.createGameStatisticsPersistenceWorker();
+    await worker.execute(gameStats);
+  }
+}

--- a/server/src/application/factories/StatisticsWorkerFactory.ts
+++ b/server/src/application/factories/StatisticsWorkerFactory.ts
@@ -1,3 +1,4 @@
+import { PlayerGameStatsService } from "application/services/statistics/PlayerGameStatsService";
 import { GameStatisticsPersistenceWorker } from "application/workers/GameStatisticsPersistenceWorker";
 import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
 import { GameStatisticsRepository } from "infrastructure/database/repositories/statistics/GameStatisticsRepository";
@@ -6,6 +7,7 @@ import { ILogger } from "infrastructure/logger/ILogger";
 export class StatisticsWorkerFactory {
   constructor(
     private readonly gameStatisticsRepository: GameStatisticsRepository,
+    private readonly playerGameStatsService: PlayerGameStatsService,
     private readonly logger: ILogger
   ) {
     //
@@ -14,6 +16,7 @@ export class StatisticsWorkerFactory {
   public createGameStatisticsPersistenceWorker(): GameStatisticsPersistenceWorker {
     return new GameStatisticsPersistenceWorker(
       this.gameStatisticsRepository,
+      this.playerGameStatsService,
       this.logger
     );
   }

--- a/server/src/application/handlers/TimerExpirationHandler.ts
+++ b/server/src/application/handlers/TimerExpirationHandler.ts
@@ -5,8 +5,12 @@ import { FinalRoundService } from "application/services/socket/FinalRoundService
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
 import { SocketQuestionStateService } from "application/services/socket/SocketQuestionStateService";
 import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
+import { PlayerGameStatsService } from "application/services/statistics/PlayerGameStatsService";
 import { GAME_TTL_IN_SECONDS } from "domain/constants/game";
-import { REDIS_LOCK_EXPIRATION_KEY } from "domain/constants/redis";
+import {
+  REDIS_LOCK_EXPIRATION_KEY,
+  REDIS_LOCK_QUESTION_ANSWER,
+} from "domain/constants/redis";
 import { SOCKET_GAME_NAMESPACE } from "domain/constants/socket";
 import { TIMER_NSP } from "domain/constants/timer";
 import { Game } from "domain/entities/game/Game";
@@ -47,9 +51,14 @@ export class TimerExpirationHandler implements RedisExpirationHandler {
     private readonly roundHandlerFactory: RoundHandlerFactory,
     private readonly finalRoundService: FinalRoundService,
     private readonly gameStatisticsCollectorService: GameStatisticsCollectorService,
+    private readonly playerGameStatsService: PlayerGameStatsService,
     private readonly logger: ILogger
   ) {
     //
+  }
+
+  private _getQuestionAnswerLockKey(gameId: string) {
+    return `${REDIS_LOCK_QUESTION_ANSWER}:${gameId}`;
   }
 
   public supports(key: string): boolean {
@@ -57,8 +66,8 @@ export class TimerExpirationHandler implements RedisExpirationHandler {
   }
 
   public async handle(key: string): Promise<void> {
-    const lockKey = `${REDIS_LOCK_EXPIRATION_KEY}:${key}`;
-    const acquired = await this.redisService.setLockKey(lockKey);
+    const expirationLockKey = `${REDIS_LOCK_EXPIRATION_KEY}:${key}`;
+    const acquired = await this.redisService.setLockKey(expirationLockKey);
 
     if (!acquired) {
       this.logger.debug(
@@ -150,6 +159,8 @@ export class TimerExpirationHandler implements RedisExpirationHandler {
           question
         );
 
+        // Release the question answer lock
+
         this._gameNamespace.to(gameId).emit(SocketIOGameEvents.ANSWER_RESULT, {
           answerResult,
           timer,
@@ -161,6 +172,19 @@ export class TimerExpirationHandler implements RedisExpirationHandler {
       this._gameNamespace.to(gameId).emit(SocketIOEvents.ERROR, {
         message: error.message,
       });
+    } finally {
+      // Always release all locks
+      try {
+        await this.redisService.del(expirationLockKey);
+
+        const questionLockKey = this._getQuestionAnswerLockKey(gameId);
+        await this.gameService.gameUnlock(questionLockKey);
+      } catch (error) {
+        this.logger.warn("Failed to release timer expiration lock", {
+          lockKey: expirationLockKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
@@ -180,6 +204,24 @@ export class TimerExpirationHandler implements RedisExpirationHandler {
       AnswerResultType.WRONG,
       nextState
     );
+
+    // Update player answer statistics for timeout (wrong answer)
+    try {
+      await this.playerGameStatsService.updatePlayerAnswerStats(
+        game.id,
+        playerAnswerResult.player,
+        AnswerResultType.WRONG, // timeout is always wrong
+        playerAnswerResult.score
+      );
+    } catch (error) {
+      // Log but don't throw - statistics shouldn't break game flow
+      this.logger.warn("Failed to update player answer statistics on timeout", {
+        prefix: "[TIMER_EXPIRATION_HANDLER]: ",
+        gameId: game.id,
+        playerId: playerAnswerResult.player,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     const timer = await this.gameService.getTimer(
       game.id,

--- a/server/src/application/services/game/GameService.ts
+++ b/server/src/application/services/game/GameService.ts
@@ -77,6 +77,23 @@ export class GameService {
     this.io.emit(SocketIOEvents.GAMES, eventDataDTO);
   }
 
+  /**
+   * **Warning:** This method bypasses host check, so it can be used only in
+   * automated flows (e.g. when everyone leaves and game is finished)
+   */
+  public async deleteInternally(gameId: string) {
+    await this.gameRepository.deleteInternally(gameId);
+
+    const eventDataDTO: GameEventDTO = {
+      event: GameEvent.DELETED,
+      data: {
+        id: gameId,
+      },
+    };
+
+    this.io.emit(SocketIOEvents.GAMES, eventDataDTO);
+  }
+
   public async create(req: Request, gameData: GameCreateDTO) {
     const createdByUser = await this.userService.getUserByRequest(req, {
       select: ["id", "username"],

--- a/server/src/application/services/game/GameService.ts
+++ b/server/src/application/services/game/GameService.ts
@@ -162,6 +162,10 @@ export class GameService {
     return this.gameRepository.gameLock(key, expire);
   }
 
+  public async gameUnlock(key: string): Promise<number> {
+    return this.gameRepository.gameUnlock(key);
+  }
+
   private _emitSocketGameCreated(gameData: GameListItemDTO) {
     const eventDataDTO: GameEventDTO = {
       event: GameEvent.CREATED,

--- a/server/src/application/services/statistics/GameStatisticsCollectorService.ts
+++ b/server/src/application/services/statistics/GameStatisticsCollectorService.ts
@@ -1,0 +1,109 @@
+import { StatisticsWorkerFactory } from "application/factories/StatisticsWorkerFactory";
+import { GameStatisticsService } from "application/services/statistics/GameStatisticsService";
+import { Game } from "domain/entities/game/Game";
+import { GameMode } from "domain/enums/GameMode";
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+import { ILogger } from "infrastructure/logger/ILogger";
+
+/**
+ * Service responsible for collecting game statistics during gameplay
+ * Stores data temporarily in Redis during game progression
+ */
+export class GameStatisticsCollectorService {
+  constructor(
+    private readonly statisticsService: GameStatisticsService,
+    private readonly statisticsWorkerFactory: StatisticsWorkerFactory,
+    private readonly logger: ILogger
+  ) {
+    //
+  }
+
+  /**
+   * Start collecting statistics for a game when it begins
+   */
+  public async startCollection(
+    gameId: string,
+    startedAt: Date,
+    createdBy: number,
+    game: Game
+  ): Promise<void> {
+    const data: GameStatisticsData = {
+      gameId,
+      startedAt,
+      finishedAt: null,
+      createdBy,
+      duration: null,
+      totalPlayers: game.playersCount,
+      gameMode: GameMode.DEFAULT,
+      totalRounds: game.roundsCount,
+      totalQuestions: game.questionsCount,
+    };
+
+    await this.statisticsService.save(data);
+  }
+
+  /**
+   * Finish collecting statistics when game ends.
+   * Automatically saves statistics to database and cleans up Redis
+   */
+  public async finishCollection(gameId: string): Promise<void> {
+    this.logger.debug(`Collect statistics for game`, {
+      prefix: "[GAME_STATISTICS_COLLECTOR]: ",
+      gameId,
+    });
+
+    const finishedAt = new Date();
+
+    const gameStats = await this.statisticsService.get(gameId);
+    if (!gameStats) {
+      this.logger.warn(
+        `No statistics found for game ${gameId}, cannot finish collection`,
+        {
+          prefix: "[GAME_STATISTICS_COLLECTOR]: ",
+        }
+      );
+      return;
+    }
+
+    const duration = finishedAt.getTime() - gameStats.startedAt.getTime();
+
+    await this.statisticsService.update(gameStats, {
+      finishedAt,
+      duration,
+    });
+
+    this.logger.info(`Statistics collection finished for game`, {
+      prefix: "[GAME_STATISTICS_COLLECTOR]: ",
+      gameId,
+      duration: `${duration}ms`,
+    });
+
+    const updatedStats = {
+      ...gameStats,
+      finishedAt,
+      duration,
+    };
+
+    // Save statistics to DB and clean up live statistics from Redis
+    await this.statisticsWorkerFactory.executeGameStatisticsPersistence(
+      updatedStats
+    );
+  }
+
+  /**
+   * Check if statistics collection is active for a game
+   */
+  public async isCollecting(gameId: string): Promise<boolean> {
+    const stats = await this.statisticsService.get(gameId);
+    return stats !== null && stats.finishedAt === null;
+  }
+
+  /**
+   * Get current statistics for a game
+   */
+  public async getCurrentStats(
+    gameId: string
+  ): Promise<GameStatisticsData | null> {
+    return this.statisticsService.get(gameId);
+  }
+}

--- a/server/src/application/services/statistics/GameStatisticsService.ts
+++ b/server/src/application/services/statistics/GameStatisticsService.ts
@@ -1,0 +1,43 @@
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+import { GameStatisticsRepository } from "infrastructure/database/repositories/statistics/GameStatisticsRepository";
+
+/**
+ * Provides abstraction over live statistics operations in Redis
+ * TODO: Currently works only as adapter for repository, but can be extended in future
+ */
+export class GameStatisticsService {
+  constructor(private readonly repository: GameStatisticsRepository) {
+    //
+  }
+
+  /**
+   * Create live game statistics in Redis when game starts
+   */
+  public async save(data: GameStatisticsData): Promise<void> {
+    return this.repository.createLiveStatistics(data);
+  }
+
+  /**
+   * Get live game statistics from Redis during gameplay
+   */
+  public async get(gameId: string): Promise<GameStatisticsData | null> {
+    return this.repository.getLiveStatistics(gameId);
+  }
+
+  /**
+   * Delete live game statistics from Redis after persistence
+   */
+  public async delete(gameId: string): Promise<void> {
+    return this.repository.deleteLiveStatistics(gameId);
+  }
+
+  /**
+   * Update live game statistics in Redis during gameplay
+   */
+  public async update(
+    gameStats: GameStatisticsData,
+    updates: Partial<GameStatisticsData>
+  ): Promise<void> {
+    return this.repository.updateLiveStatistics(gameStats, updates);
+  }
+}

--- a/server/src/application/services/statistics/PlayerGameStatsService.ts
+++ b/server/src/application/services/statistics/PlayerGameStatsService.ts
@@ -1,0 +1,205 @@
+import { Game } from "domain/entities/game/Game";
+import { PlayerGameStatus } from "domain/types/game/PlayerGameStatus";
+import { PlayerRole } from "domain/types/game/PlayerRole";
+import { PlayerGameStatsData } from "domain/types/statistics/PlayerGameStatsData";
+import { PlayerGameStatsRepository } from "infrastructure/database/repositories/statistics/PlayerGameStatsRepository";
+import { ILogger } from "infrastructure/logger/ILogger";
+
+/**
+ * Service for managing player game statistics
+ */
+export class PlayerGameStatsService {
+  constructor(
+    private readonly repository: PlayerGameStatsRepository,
+    private readonly logger: ILogger
+  ) {
+    //
+  }
+
+  /**
+   * Initialize player session in Redis when they join a game
+   * This tracks live session data like join time and basic info
+   */
+  public async initializePlayerSession(
+    gameId: string,
+    userId: number,
+    joinedAt: Date
+  ): Promise<void> {
+    this.logger.debug("Initializing player session", {
+      prefix: "[PLAYER_GAME_STATS]: ",
+      gameId,
+      userId,
+    });
+
+    // Create initial session data in Redis for live tracking
+    const sessionData = {
+      gameId,
+      userId,
+      joinedAt,
+      leftAt: null,
+      currentScore: 0,
+      questionsAnswered: 0,
+      correctAnswers: 0,
+      wrongAnswers: 0,
+    };
+
+    try {
+      await this.repository.initializeStats(gameId, userId, sessionData);
+    } catch (error) {
+      this.logger.warn("Failed to initialize player statistics session", {
+        prefix: "[PLAYER_GAME_STATS]: ",
+        gameId: gameId,
+        userId: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * End player live session in Redis when they leave a game
+   * This updates the leave time and saves final session stats
+   */
+  public async endPlayerSession(
+    gameId: string,
+    userId: number,
+    leftAt: Date
+  ): Promise<void> {
+    this.logger.debug("Ending player session", {
+      prefix: "[PLAYER_GAME_STATS]: ",
+      gameId,
+      userId,
+    });
+
+    try {
+      // Update session with leave time and finalize
+      await this.repository.updateStats(gameId, userId, { leftAt });
+    } catch (error) {
+      this.logger.error("Failed to end player session", {
+        prefix: "[PLAYER_GAME_STATS]: ",
+        gameId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  public async clearPlayerLeftAtTime(
+    gameId: string,
+    userId: number
+  ): Promise<void> {
+    try {
+      await this.repository.updateStats(gameId, userId, { leftAt: null });
+    } catch (error) {
+      this.logger.error("Failed to clear player left time", {
+        prefix: "[PLAYER_GAME_STATS]: ",
+        gameId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Collect and save player statistics for a finished game
+   */
+  public async collectGamePlayerStats(
+    gameStatsId: number,
+    game: Game,
+    gameStartedAt: Date
+  ): Promise<void> {
+    this.logger.debug("Collecting player game statistics", {
+      prefix: "[PLAYER_GAME_STATS]: ",
+      gameId: game.id,
+      gameStatsId,
+    });
+
+    const players = game.players.filter((p) => p.role === PlayerRole.PLAYER);
+    const playerStatsData: PlayerGameStatsData[] = [];
+
+    for (const player of players) {
+      // Calculate basic performance metrics
+      const correctAnswers = this._calculateCorrectAnswers(
+        game,
+        player.meta.id
+      );
+      const wrongAnswers = this._calculateWrongAnswers(game, player.meta.id);
+      const questionsAnswered = correctAnswers + wrongAnswers;
+
+      const playerData: PlayerGameStatsData = {
+        gameStatsId,
+        userId: player.meta.id,
+        finalScore: player.score,
+        placement: null, // Will be calculated after all players are saved
+        joinedAt: gameStartedAt, // For now, use game start time
+        leftAt:
+          player.gameStatus === PlayerGameStatus.DISCONNECTED
+            ? new Date() // If disconnected, mark as left
+            : null,
+        questionsAnswered,
+        correctAnswers,
+        wrongAnswers,
+      };
+
+      playerStatsData.push(playerData);
+    }
+
+    // Save all player statistics
+    await this.repository.saveMany(playerStatsData);
+
+    // Calculate and update placements based on final scores
+    await this.repository.updatePlacements(gameStatsId);
+
+    this.logger.info("Player game statistics collected successfully", {
+      prefix: "[PLAYER_GAME_STATS]: ",
+      gameId: game.id,
+      playersCount: playerStatsData.length,
+    });
+  }
+
+  /**
+   * Get player statistics for a specific game
+   */
+  public async getGamePlayerStats(gameStatsId: number) {
+    return this.repository.getByGameStatsId(gameStatsId);
+  }
+
+  /**
+   * Get player statistics history for a user
+   */
+  public async getUserPlayerStats(userId: number, limit = 50) {
+    return this.repository.getByUserId(userId, limit);
+  }
+
+  /**
+   * Calculate number of correct answers for a player in a game
+   */
+  private _calculateCorrectAnswers(game: Game, playerId: number): number {
+    // For now, we'll use a simple heuristic since we don't have detailed answer tracking yet
+    // This can be enhanced when we implement more detailed event tracking
+
+    if (!game.gameState?.answeredPlayers) {
+      return 0;
+    }
+
+    // Count correct answers from the answered players array
+    return game.gameState.answeredPlayers.filter(
+      (ap) => ap.player === playerId && ap.result > 0
+    ).length;
+  }
+
+  /**
+   * Calculate number of wrong answers for a player in a game
+   */
+  private _calculateWrongAnswers(game: Game, playerId: number): number {
+    if (!game.gameState?.answeredPlayers) {
+      return 0;
+    }
+
+    // Count wrong answers from the answered players array
+    return game.gameState.answeredPlayers.filter(
+      (ap) => ap.player === playerId && ap.result < 0
+    ).length;
+  }
+}

--- a/server/src/application/workers/GameStatisticsPersistenceWorker.ts
+++ b/server/src/application/workers/GameStatisticsPersistenceWorker.ts
@@ -1,0 +1,70 @@
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+import { GameStatisticsRepository } from "infrastructure/database/repositories/statistics/GameStatisticsRepository";
+import { ILogger } from "infrastructure/logger/ILogger";
+
+/**
+ * Worker responsible for persisting game statistics from Redis to database
+ * Executes in background when game finishes to avoid blocking game flow
+ */
+export class GameStatisticsPersistenceWorker {
+  constructor(
+    private readonly repository: GameStatisticsRepository,
+    private readonly logger: ILogger
+  ) {
+    //
+  }
+
+  /**
+   * Execute the persistence workflow for a completed game
+   * This method should be called when GAME_FINISHED event is emitted
+   */
+  public async execute(gameStats: GameStatisticsData): Promise<void> {
+    this.logger.debug(`Saving game stats to DB`, {
+      prefix: "[GAME_STATISTICS_WORKER]: ",
+      gameId: gameStats.gameId,
+    });
+
+    try {
+      // Validate that the game is actually finished
+      if (!gameStats.finishedAt) {
+        this.logger.warn(
+          `Game statistics for ${gameStats.gameId} are incomplete (not finished), skipping persistence`,
+          {
+            prefix: "[GAME_STATISTICS_WORKER]: ",
+            hasFinishedAt: !!gameStats.finishedAt,
+            hasDuration: !!gameStats.duration,
+          }
+        );
+        return;
+      }
+
+      // Create persistent record in database
+      const savedStats = await this.repository.createPersistentStatistics(
+        gameStats
+      );
+
+      this.logger.info(`Game statistics saved to DB`, {
+        prefix: "[GAME_STATISTICS_WORKER]: ",
+        gameId: gameStats.gameId,
+        statisticsId: savedStats.id,
+        gameDuration: `${(gameStats.duration ?? 0) * 1000 * 60} minutes`,
+      });
+
+      // Clean up live statistics from Redis after successful persistence
+      await this.repository.deleteLiveStatistics(gameStats.gameId);
+
+      this.logger.debug(`Cleaned up live statistics from Redis`, {
+        prefix: "[GAME_STATISTICS_WORKER]: ",
+        gameId: gameStats.gameId,
+      });
+    } catch (error) {
+      // Log error but don't rethrow - we don't want to break game flow
+      this.logger.error(
+        `Failed to persist game statistics for game ${gameStats.gameId}: ${error}`,
+        {
+          prefix: "[GAME_STATISTICS_WORKER]: ",
+        }
+      );
+    }
+  }
+}

--- a/server/src/domain/constants/statistics.ts
+++ b/server/src/domain/constants/statistics.ts
@@ -1,0 +1,6 @@
+export const GAME_STATISTICS_REDIS_NSP = "statistics:game";
+export const PLAYER_STATISTICS_REDIS_NSP = "statistics:player";
+/** 24 hours */
+export const GAME_STATISTICS_TTL = 24 * 60 * 60;
+/** 24 hours */
+export const PLAYER_STATISTICS_TTL = 24 * 60 * 60;

--- a/server/src/domain/enums/GameMode.ts
+++ b/server/src/domain/enums/GameMode.ts
@@ -1,0 +1,3 @@
+export enum GameMode {
+  DEFAULT = "default",
+}

--- a/server/src/domain/handlers/socket/SocketEventHandlerFactory.ts
+++ b/server/src/domain/handlers/socket/SocketEventHandlerFactory.ts
@@ -5,6 +5,7 @@ import { SocketIOChatService } from "application/services/socket/SocketIOChatSer
 import { SocketIOGameService } from "application/services/socket/SocketIOGameService";
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
 import { UserNotificationRoomService } from "application/services/socket/UserNotificationRoomService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
 import { BaseSocketEventHandler } from "domain/handlers/socket/BaseSocketEventHandler";
 import { FinalAnswerReviewEventHandler } from "domain/handlers/socket/finalround/FinalAnswerReviewEventHandler";
 import { FinalAnswerSubmitEventHandler } from "domain/handlers/socket/finalround/FinalAnswerSubmitEventHandler";
@@ -50,6 +51,7 @@ export class SocketEventHandlerFactory {
     private readonly finalRoundService: FinalRoundService,
     private readonly userNotificationRoomService: UserNotificationRoomService,
     private readonly socketIOQuestionService: SocketIOQuestionService,
+    private readonly gameStatisticsCollectorService: GameStatisticsCollectorService,
     private readonly logger: ILogger
   ) {
     //
@@ -89,7 +91,8 @@ export class SocketEventHandlerFactory {
         socket,
         eventEmitter,
         this.logger,
-        this.socketIOGameService
+        this.socketIOGameService,
+        this.gameStatisticsCollectorService
       ),
       new PauseGameEventHandler(
         socket,
@@ -211,13 +214,15 @@ export class SocketEventHandlerFactory {
         socket,
         eventEmitter,
         this.logger,
-        this.socketIOQuestionService
+        this.socketIOQuestionService,
+        this.gameStatisticsCollectorService
       ),
       new SkipQuestionEventHandler(
         socket,
         eventEmitter,
         this.logger,
-        this.socketIOQuestionService
+        this.socketIOQuestionService,
+        this.gameStatisticsCollectorService
       ),
       new QuestionSkipEventHandler(
         socket,
@@ -276,7 +281,8 @@ export class SocketEventHandlerFactory {
         socket,
         eventEmitter,
         this.logger,
-        this.finalRoundService
+        this.finalRoundService,
+        this.gameStatisticsCollectorService
       ),
     ];
   }

--- a/server/src/domain/handlers/socket/game/LeaveGameEventHandler.ts
+++ b/server/src/domain/handlers/socket/game/LeaveGameEventHandler.ts
@@ -9,6 +9,7 @@ import {
   SocketEventContext,
   SocketEventResult,
 } from "domain/handlers/socket/BaseSocketEventHandler";
+import { PlayerGameStatus } from "domain/types/game/PlayerGameStatus";
 import {
   EmptyInputData,
   GameLeaveBroadcastData,
@@ -113,6 +114,14 @@ export class LeaveGameEventHandler extends BaseSocketEventHandler<
             context.gameId,
             result.data.user
           );
+        }
+
+        const activePlayers = game.players.filter(
+          (p) => p.gameStatus === PlayerGameStatus.IN_GAME
+        );
+
+        if (activePlayers.length === 0) {
+          await this.socketIOGameService.deleteGameInternally(context.gameId);
         }
       } catch (error) {
         // Game might not exist anymore, just clean up socket room

--- a/server/src/domain/handlers/socket/game/NextRoundEventHandler.ts
+++ b/server/src/domain/handlers/socket/game/NextRoundEventHandler.ts
@@ -1,6 +1,7 @@
 import { Socket } from "socket.io";
 
 import { SocketIOGameService } from "application/services/socket/SocketIOGameService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
 import { SocketIOGameEvents } from "domain/enums/SocketIOEvents";
 import {
   BaseSocketEventHandler,
@@ -24,7 +25,8 @@ export class NextRoundEventHandler extends BaseSocketEventHandler<
     socket: Socket,
     eventEmitter: SocketIOEventEmitter,
     logger: ILogger,
-    private readonly socketIOGameService: SocketIOGameService
+    private readonly socketIOGameService: SocketIOGameService,
+    private readonly gameStatisticsCollectorService: GameStatisticsCollectorService
   ) {
     super(socket, eventEmitter, logger);
   }
@@ -83,6 +85,16 @@ export class NextRoundEventHandler extends BaseSocketEventHandler<
         target: SocketBroadcastTarget.GAME,
         gameId: game.id,
       });
+
+      // Trigger statistics persistence
+      try {
+        await this.gameStatisticsCollectorService.finishCollection(game.id);
+      } catch (error) {
+        this.logger.warn("Failed to execute statistics persistence", {
+          gameId: game.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
 
       return {
         success: true,

--- a/server/src/domain/handlers/socket/question/AnswerResultEventHandler.ts
+++ b/server/src/domain/handlers/socket/question/AnswerResultEventHandler.ts
@@ -1,6 +1,7 @@
 import { Socket } from "socket.io";
 
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
 import { SocketIOGameEvents } from "domain/enums/SocketIOEvents";
 import {
   BaseSocketEventHandler,
@@ -29,7 +30,8 @@ export class AnswerResultEventHandler extends BaseSocketEventHandler<
     socket: Socket,
     eventEmitter: SocketIOEventEmitter,
     logger: ILogger,
-    private readonly socketIOQuestionService: SocketIOQuestionService
+    private readonly socketIOQuestionService: SocketIOQuestionService,
+    private readonly gameStatisticsCollectorService: GameStatisticsCollectorService
   ) {
     super(socket, eventEmitter, logger);
   }
@@ -100,6 +102,17 @@ export class AnswerResultEventHandler extends BaseSocketEventHandler<
           target: SocketBroadcastTarget.GAME,
           gameId: game.id,
         });
+
+        // Finish statistics collection and trigger persistence
+        try {
+          await this.gameStatisticsCollectorService.finishCollection(game.id);
+        } catch (error) {
+          this.logger.warn("Failed to execute statistics persistence", {
+            gameId: game.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
         return {
           success: true,
           broadcast: broadcasts,

--- a/server/src/domain/mappers/GameMapper.ts
+++ b/server/src/domain/mappers/GameMapper.ts
@@ -34,7 +34,7 @@ export class GameMapper {
    * @returns Game instance
    */
   public static deserializeGameHash(
-    data: Record<string, string>,
+    data: GameRedisHashDTO,
     logger: ILogger
   ): Game {
     return new Game(

--- a/server/src/domain/types/statistics/GameStatisticsData.ts
+++ b/server/src/domain/types/statistics/GameStatisticsData.ts
@@ -1,0 +1,16 @@
+import { GameMode } from "domain/enums/GameMode";
+
+/**
+ * Game statistics data interface for temporary storage and persistence
+ */
+export interface GameStatisticsData {
+  gameId: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+  createdBy: number;
+  duration: number | null; // Duration in milliseconds
+  totalPlayers: number | null;
+  gameMode: GameMode | null;
+  totalRounds: number | null;
+  totalQuestions: number | null;
+}

--- a/server/src/domain/types/statistics/PlayerGameStatsData.ts
+++ b/server/src/domain/types/statistics/PlayerGameStatsData.ts
@@ -1,0 +1,14 @@
+/**
+ * Player game statistics data interface for individual player performance tracking
+ */
+export interface PlayerGameStatsData {
+  gameStatsId: number;
+  userId: number;
+  finalScore: number;
+  placement: number | null;
+  joinedAt: Date;
+  leftAt: Date | null;
+  questionsAnswered: number;
+  correctAnswers: number;
+  wrongAnswers: number;
+}

--- a/server/src/domain/types/statistics/PlayerGameStatsRedisData.ts
+++ b/server/src/domain/types/statistics/PlayerGameStatsRedisData.ts
@@ -1,0 +1,61 @@
+/**
+ * Interface for player game statistics data stored in Redis
+ * All values in Redis are stored as strings, so this interface reflects that
+ */
+export interface PlayerGameStatsRedisData {
+  /** Game ID this session belongs to */
+  gameId: string;
+
+  /** User ID for this session */
+  userId: string;
+
+  /** ISO timestamp when player joined the game */
+  joinedAt: string;
+
+  /** ISO timestamp when player left the game (empty string if still in game) */
+  leftAt: string;
+
+  /** Current player score */
+  currentScore: string;
+
+  /** Total number of questions the player has answered */
+  questionsAnswered: string;
+
+  /** Number of questions answered correctly */
+  correctAnswers: string;
+
+  /** Number of questions answered incorrectly */
+  wrongAnswers: string;
+}
+
+/**
+ * Partial interface for updating Redis data - allows partial updates
+ */
+export interface PlayerGameStatsRedisUpdate {
+  /** Game ID this session belongs to */
+  gameId?: string;
+
+  /** User ID for this session */
+  userId?: string;
+
+  /** ISO timestamp when player joined the game */
+  joinedAt?: string;
+
+  /** ISO timestamp when player left the game (null becomes empty string in Redis) */
+  leftAt?: string | null;
+
+  /** Current player score */
+  currentScore?: string | number;
+
+  /** Player's current score (alias for compatibility) */
+  score?: string | number;
+
+  /** Total number of questions the player has answered */
+  questionsAnswered?: string | number;
+
+  /** Number of questions answered correctly */
+  correctAnswers?: string | number;
+
+  /** Number of questions answered incorrectly */
+  wrongAnswers?: string | number;
+}

--- a/server/src/domain/validators/GameRedisValidator.ts
+++ b/server/src/domain/validators/GameRedisValidator.ts
@@ -1,0 +1,24 @@
+import { GameRedisHashDTO } from "domain/types/dto/game/GameRedisHashDTO";
+import { gameRedisDataScheme } from "presentation/schemes/game/gameSchemes";
+
+export class GameRedisValidator {
+  /**
+   * Validate Redis data and return typed result
+   * @param data Raw Redis data from hgetall or other source
+   * @returns Validated GameRedisHashDTO
+   */
+  public static validateRedisData(
+    data: Record<string, string>
+  ): GameRedisHashDTO {
+    const { value, error } = gameRedisDataScheme().validate(data, {
+      allowUnknown: false,
+      stripUnknown: true,
+    });
+
+    if (error) {
+      throw new Error(`Invalid Game Redis data: ${error.message}`);
+    }
+
+    return value;
+  }
+}

--- a/server/src/domain/validators/PlayerGameStatsRedisValidator.ts
+++ b/server/src/domain/validators/PlayerGameStatsRedisValidator.ts
@@ -1,0 +1,24 @@
+import { PlayerGameStatsRedisData } from "domain/types/statistics/PlayerGameStatsRedisData";
+import { playerGameStatsDataScheme } from "presentation/schemes/game/playerSchemes";
+
+export class PlayerGameStatsRedisValidator {
+  /**
+   * Validate Redis data and return typed result
+   * @param data Raw Redis data from hgetall or other source
+   * @returns Validated PlayerGameStatsRedisData
+   */
+  public static validateRedisData(
+    data: Record<string, string>
+  ): PlayerGameStatsRedisData {
+    const { value, error } = playerGameStatsDataScheme().validate(data, {
+      allowUnknown: false,
+      stripUnknown: true,
+    });
+
+    if (error) {
+      throw new Error(`Invalid PlayerGameStats Redis data: ${error.message}`);
+    }
+
+    return value;
+  }
+}

--- a/server/src/infrastructure/database/DataSource.ts
+++ b/server/src/infrastructure/database/DataSource.ts
@@ -17,6 +17,8 @@ import { PackageRound } from "infrastructure/database/models/package/PackageRoun
 import { PackageTag } from "infrastructure/database/models/package/PackageTag";
 import { PackageTheme } from "infrastructure/database/models/package/PackageTheme";
 import { Permission } from "infrastructure/database/models/Permission";
+import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
+import { PlayerGameStats } from "infrastructure/database/models/statistics/PlayerGameStats";
 import { User } from "infrastructure/database/models/User";
 import { PinoLogger } from "infrastructure/logger/PinoLogger";
 
@@ -30,6 +32,9 @@ import { AddTypeToPackageRound_1747924851733 as AddTypeToPackageRound } from "in
 import { MakePackageQuestionPriceNullable_1747925123456 as MakePackageQuestionPriceNullable } from "infrastructure/database/migrations/0.15.2_MakePackageQuestionPriceNullable";
 import { MakeAnswerAndQuestionDisplayTimeNullable_1747925123456 as MakeDisplayTimeNullable } from "infrastructure/database/migrations/0.15.2_Part2MakeDisplayTimeNullable";
 import { AddSearchIndexes_0_15_3_1752686138751 as AddSearchIndexes } from "infrastructure/database/migrations/0.15.3_AddSearchIndexes";
+import { ExtendGameStatisticsTable_0_17_0_2_1754379301456 as ExtendGameStatistics } from "infrastructure/database/migrations/0.17.0-2_ExtendGameStatisticsTable";
+import { AddPlayerGameStatsTable_0_17_0_3_1754379351456 as AddPlayerGameStats } from "infrastructure/database/migrations/0.17.0-3_AddPlayerGameStatsTable";
+import { AddGameStatisticsTable_0_17_0_1754379291456 as AddGameStatistics } from "infrastructure/database/migrations/0.17.0_AddGameStatisticsTable";
 import { WriteMoreInfoToDB_0_2_9_1725692779638 as writeMoreToDB } from "infrastructure/database/migrations/0.2.9_WriteMoreInfoToDB";
 import { ChangePermissionValidation_0_3_0_1729181792142 as changePermissionValidation } from "infrastructure/database/migrations/0.3.0_ChangePermissionValidation";
 import { AddDeleteFilePermission_0_3_9_1730832569761 as addDeletePermission } from "infrastructure/database/migrations/0.3.9_AddDeleteFilePermission";
@@ -83,6 +88,8 @@ export const AppDataSource = new DataSource({
     PackageTag,
     PackageTheme,
     PackageQuestionChoiceAnswer,
+    GameStatistics,
+    PlayerGameStats,
   ],
   migrations: [
     createUserAndFileTables,
@@ -105,6 +112,9 @@ export const AppDataSource = new DataSource({
     MakePackageQuestionPriceNullable,
     MakeDisplayTimeNullable,
     AddSearchIndexes,
+    AddGameStatistics,
+    ExtendGameStatistics,
+    AddPlayerGameStats,
   ],
   poolSize: 25,
   migrationsRun: true,

--- a/server/src/infrastructure/database/migrations/0.17.0-2_ExtendGameStatisticsTable.ts
+++ b/server/src/infrastructure/database/migrations/0.17.0-2_ExtendGameStatisticsTable.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+import { PinoLogger } from "infrastructure/logger/PinoLogger";
+
+export class ExtendGameStatisticsTable_0_17_0_2_1754379301456
+  implements MigrationInterface
+{
+  name = "ExtendGameStatisticsTable_0_17_0_2_1754379301456";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create enum type for game_mode
+    await queryRunner.query(`
+      CREATE TYPE game_mode_enum AS ENUM ('default')
+    `);
+
+    // Add new columns to game_statistics table for Phase 1 metrics
+    await queryRunner.addColumns("game_statistics", [
+      new TableColumn({
+        name: "total_players",
+        type: "int",
+        isNullable: true, // Allow null for existing records (same for all other)
+      }),
+      new TableColumn({
+        name: "game_mode",
+        type: "game_mode_enum",
+        isNullable: true,
+        default: "'default'",
+      }),
+      new TableColumn({
+        name: "total_rounds",
+        type: "int",
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: "total_questions",
+        type: "int",
+        isNullable: true,
+      }),
+    ]);
+
+    // Add indexes for common query patterns
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_game_statistics_game_mode ON game_statistics (game_mode)"
+    );
+
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_game_statistics_total_players ON game_statistics (total_players)"
+    );
+
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_game_statistics_started_at ON game_statistics (started_at)"
+    );
+
+    const logger = await PinoLogger.init({ pretty: true });
+    logger.migration("0.17.0-2");
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the added indexes
+    await queryRunner.query(
+      "DROP INDEX IF EXISTS idx_game_statistics_game_mode"
+    );
+    await queryRunner.query(
+      "DROP INDEX IF EXISTS idx_game_statistics_total_players"
+    );
+    await queryRunner.query(
+      "DROP INDEX IF EXISTS idx_game_statistics_started_at"
+    );
+
+    // Drop the added columns
+    await queryRunner.dropColumns("game_statistics", [
+      "total_players",
+      "game_mode",
+      "total_rounds",
+      "total_questions",
+    ]);
+
+    // Drop the enum type
+    await queryRunner.query("DROP TYPE IF EXISTS game_mode_enum");
+  }
+}

--- a/server/src/infrastructure/database/migrations/0.17.0-3_AddPlayerGameStatsTable.ts
+++ b/server/src/infrastructure/database/migrations/0.17.0-3_AddPlayerGameStatsTable.ts
@@ -1,0 +1,139 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from "typeorm";
+
+import { PinoLogger } from "infrastructure/logger/PinoLogger";
+
+export class AddPlayerGameStatsTable_0_17_0_3_1754379351456
+  implements MigrationInterface
+{
+  name = "AddPlayerGameStatsTable_0_17_0_3_1754379351456";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create player_game_stats table for individual player performance tracking
+    await queryRunner.createTable(
+      new Table({
+        name: "player_game_stats",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: "increment",
+          },
+          {
+            name: "user_id",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "game_stats_id",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "final_score",
+            type: "int",
+            isNullable: false,
+            default: 0,
+          },
+          {
+            name: "placement",
+            type: "int",
+            isNullable: true,
+          },
+          {
+            name: "joined_at",
+            type: "timestamp",
+            isNullable: false,
+          },
+          {
+            name: "left_at",
+            type: "timestamp",
+            isNullable: true,
+          },
+          {
+            name: "questions_answered",
+            type: "int",
+            isNullable: false,
+            default: 0,
+          },
+          {
+            name: "correct_answers",
+            type: "int",
+            isNullable: false,
+            default: 0,
+          },
+          {
+            name: "wrong_answers",
+            type: "int",
+            isNullable: false,
+            default: 0,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "CURRENT_TIMESTAMP",
+          },
+        ],
+      }),
+      true
+    );
+
+    // Add foreign key constraint to game_statistics
+    await queryRunner.createForeignKey(
+      "player_game_stats",
+      new TableForeignKey({
+        columnNames: ["game_stats_id"],
+        referencedTableName: "game_statistics",
+        referencedColumnNames: ["id"],
+        onDelete: "CASCADE",
+      })
+    );
+
+    // Add foreign key constraint to user table
+    await queryRunner.createForeignKey(
+      "player_game_stats",
+      new TableForeignKey({
+        columnNames: ["user_id"],
+        referencedTableName: "user",
+        referencedColumnNames: ["id"],
+        onDelete: "CASCADE",
+      })
+    );
+
+    // Add indexes for common query patterns
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_player_game_stats_game_id ON player_game_stats (game_stats_id)"
+    );
+
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_player_game_stats_user_id ON player_game_stats (user_id)"
+    );
+
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_player_game_stats_final_score ON player_game_stats (final_score)"
+    );
+
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_player_game_stats_placement ON player_game_stats (placement)"
+    );
+
+    // Unique constraint to prevent duplicate player entries per game
+    await queryRunner.query(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_player_game_stats_unique_player_game ON player_game_stats (game_stats_id, user_id)"
+    );
+
+    const logger = await PinoLogger.init({ pretty: true });
+    logger.migration("0.17.0-3");
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the table (this will automatically drop foreign keys and indexes)
+    await queryRunner.dropTable("player_game_stats", true);
+  }
+}

--- a/server/src/infrastructure/database/migrations/0.17.0_AddGameStatisticsTable.ts
+++ b/server/src/infrastructure/database/migrations/0.17.0_AddGameStatisticsTable.ts
@@ -1,0 +1,92 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from "typeorm";
+
+import { PinoLogger } from "infrastructure/logger/PinoLogger";
+
+export class AddGameStatisticsTable_0_17_0_1754379291456
+  implements MigrationInterface
+{
+  name = "AddGameStatisticsTable_0_17_0_1754379291456";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create game_statistics table
+    await queryRunner.createTable(
+      new Table({
+        name: "game_statistics",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: "increment",
+          },
+          {
+            name: "game_id",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "started_at",
+            type: "timestamp",
+            isNullable: false,
+          },
+          {
+            name: "finished_at",
+            type: "timestamp",
+            isNullable: false,
+          },
+          {
+            name: "created_by",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "duration",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "CURRENT_TIMESTAMP",
+          },
+        ],
+      }),
+      true
+    );
+
+    // Add foreign key constraint for created_by -> user.id
+    await queryRunner.createForeignKey(
+      "game_statistics",
+      new TableForeignKey({
+        columnNames: ["created_by"],
+        referencedTableName: "user",
+        referencedColumnNames: ["id"],
+        onDelete: "CASCADE",
+      })
+    );
+
+    // Add index for game_id for faster lookups
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_game_statistics_game_id ON game_statistics (game_id)"
+    );
+
+    // Add index for created_by for user statistics
+    await queryRunner.query(
+      "CREATE INDEX IF NOT EXISTS idx_game_statistics_created_by ON game_statistics (created_by)"
+    );
+
+    const logger = await PinoLogger.init({ pretty: true });
+    logger.migration("0.17.0");
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the table (this will automatically drop the foreign key and indexes)
+    await queryRunner.dropTable("game_statistics", true);
+  }
+}

--- a/server/src/infrastructure/database/models/statistics/GameStatistics.ts
+++ b/server/src/infrastructure/database/models/statistics/GameStatistics.ts
@@ -1,0 +1,82 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+import { GameMode } from "domain/enums/GameMode";
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+
+@Entity("game_statistics")
+export class GameStatistics {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", nullable: false })
+  game_id!: string;
+
+  @Column({ type: "timestamp", nullable: false })
+  started_at!: Date;
+
+  @Column({ type: "timestamp", nullable: false })
+  finished_at!: Date;
+
+  @Column({ type: "int", nullable: false })
+  created_by!: number;
+
+  @Column({ type: "int", nullable: false })
+  duration!: number;
+
+  @Column({ type: "int", nullable: true })
+  total_players!: number | null;
+
+  @Column({
+    type: "enum",
+    enum: GameMode,
+    nullable: true,
+    default: GameMode.DEFAULT,
+  })
+  game_mode!: GameMode | null;
+
+  @Column({ type: "int", nullable: true })
+  total_rounds!: number | null;
+
+  @Column({ type: "int", nullable: true })
+  total_questions!: number | null;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  /**
+   * Import data from GameStatisticsData interface
+   */
+  public import(data: GameStatisticsData): void {
+    this.game_id = data.gameId;
+    this.started_at = data.startedAt;
+    this.finished_at = data.finishedAt!;
+    this.created_by = data.createdBy;
+    this.duration = data.duration!;
+    this.total_players = data.totalPlayers;
+    this.game_mode = data.gameMode ?? GameMode.DEFAULT;
+    this.total_rounds = data.totalRounds;
+    this.total_questions = data.totalQuestions;
+  }
+
+  /**
+   * Convert to GameStatisticsData interface
+   */
+  public toData(): GameStatisticsData {
+    return {
+      gameId: this.game_id,
+      startedAt: this.started_at,
+      finishedAt: this.finished_at,
+      createdBy: this.created_by,
+      duration: this.duration,
+      totalPlayers: this.total_players ?? null,
+      gameMode: this.game_mode ?? null,
+      totalRounds: this.total_rounds ?? null,
+      totalQuestions: this.total_questions ?? null,
+    };
+  }
+}

--- a/server/src/infrastructure/database/models/statistics/PlayerGameStats.ts
+++ b/server/src/infrastructure/database/models/statistics/PlayerGameStats.ts
@@ -1,0 +1,90 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+import { PlayerGameStatsData } from "domain/types/statistics/PlayerGameStatsData";
+import { User } from "infrastructure/database/models/User";
+
+import { GameStatistics } from "./GameStatistics";
+
+@Entity("player_game_stats")
+export class PlayerGameStats {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "int", nullable: false })
+  game_stats_id!: number;
+
+  @Column({ type: "int", nullable: false })
+  user_id!: number;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  final_score!: number;
+
+  @Column({ type: "int", nullable: true })
+  placement?: number | null;
+
+  @Column({ type: "timestamp", nullable: false })
+  joined_at!: Date;
+
+  @Column({ type: "timestamp", nullable: true })
+  left_at?: Date | null;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  questions_answered!: number;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  correct_answers!: number;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  wrong_answers!: number;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  // Relations
+  @ManyToOne(() => GameStatistics, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "game_stats_id" })
+  gameStats!: GameStatistics;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  /**
+   * Import data from PlayerGameStatsData interface
+   */
+  public import(data: PlayerGameStatsData): void {
+    this.game_stats_id = data.gameStatsId;
+    this.user_id = data.userId;
+    this.final_score = data.finalScore;
+    this.placement = data.placement;
+    this.joined_at = data.joinedAt;
+    this.left_at = data.leftAt;
+    this.questions_answered = data.questionsAnswered;
+    this.correct_answers = data.correctAnswers;
+    this.wrong_answers = data.wrongAnswers;
+  }
+
+  /**
+   * Convert to PlayerGameStatsData interface
+   */
+  public toData(): PlayerGameStatsData {
+    return {
+      gameStatsId: this.game_stats_id,
+      userId: this.user_id,
+      finalScore: this.final_score,
+      placement: this.placement ?? null,
+      joinedAt: this.joined_at,
+      leftAt: this.left_at ?? null,
+      questionsAnswered: this.questions_answered,
+      correctAnswers: this.correct_answers,
+      wrongAnswers: this.wrong_answers,
+    };
+  }
+}

--- a/server/src/infrastructure/database/repositories/GameRepository.ts
+++ b/server/src/infrastructure/database/repositories/GameRepository.ts
@@ -22,6 +22,7 @@ import { PlayerGameStatus } from "domain/types/game/PlayerGameStatus";
 import { GamePaginationOpts } from "domain/types/pagination/game/GamePaginationOpts";
 import { PaginatedResult } from "domain/types/pagination/PaginatedResult";
 import { ShortUserInfo } from "domain/types/user/ShortUserInfo";
+import { GameRedisValidator } from "domain/validators/GameRedisValidator";
 import { GameIndexManager } from "infrastructure/database/managers/game/GameIndexManager";
 import { User } from "infrastructure/database/models/User";
 import { ILogger } from "infrastructure/logger/ILogger";
@@ -60,7 +61,8 @@ export class GameRepository {
       );
     }
 
-    return GameMapper.deserializeGameHash(data, this.logger);
+    const validatedData = GameRedisValidator.validateRedisData(data);
+    return GameMapper.deserializeGameHash(validatedData, this.logger);
   }
 
   public async updateGame(game: Game): Promise<void> {
@@ -472,12 +474,16 @@ export class GameRepository {
     return results
       .map(([, data]) => {
         try {
-          return GameMapper.deserializeGameHash(
-            data as Record<string, string>,
-            this.logger
+          const validatedData = GameRedisValidator.validateRedisData(
+            data as Record<string, string>
           );
-        } catch {
-          // Ignore invalid games
+          return GameMapper.deserializeGameHash(validatedData, this.logger);
+        } catch (error) {
+          // Log validation error and ignore invalid games
+          this.logger.warn("Skipping invalid game Redis data", {
+            prefix: "[GAME_REPOSITORY]: ",
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       })
       .filter((g): g is Game => !!g);
@@ -489,5 +495,12 @@ export class GameRepository {
   public async gameLock(key: string, expire: number): Promise<boolean> {
     const acquired = await this.redisService.setLockKey(key, expire);
     return acquired === "OK";
+  }
+
+  /**
+   * Releases a game lock by deleting the lock key from Redis
+   */
+  public async gameUnlock(key: string): Promise<number> {
+    return this.redisService.del(key);
   }
 }

--- a/server/src/infrastructure/database/repositories/statistics/GameStatisticsRepository.ts
+++ b/server/src/infrastructure/database/repositories/statistics/GameStatisticsRepository.ts
@@ -1,0 +1,147 @@
+import { Repository } from "typeorm";
+
+import {
+  GAME_STATISTICS_REDIS_NSP,
+  GAME_STATISTICS_TTL,
+} from "domain/constants/statistics";
+import { GameMode } from "domain/enums/GameMode";
+import { GameStatisticsData } from "domain/types/statistics/GameStatisticsData";
+import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
+import { RedisService } from "infrastructure/services/redis/RedisService";
+
+export class GameStatisticsRepository {
+  constructor(
+    private readonly repository: Repository<GameStatistics>,
+    private readonly redisService: RedisService
+  ) {
+    //
+  }
+
+  /**
+   * Create live game statistics in Redis when game starts
+   */
+  public async createLiveStatistics(data: GameStatisticsData): Promise<void> {
+    const key = this._getRedisKey(data.gameId);
+    await this.redisService.hset(key, data, GAME_STATISTICS_TTL);
+  }
+
+  /**
+   * Get live game statistics from Redis during gameplay
+   */
+  public async getLiveStatistics(
+    gameId: string
+  ): Promise<GameStatisticsData | null> {
+    const key = this._getRedisKey(gameId);
+    const data = await this.redisService.hgetall(key);
+
+    if (!data || Object.keys(data).length === 0) {
+      return null;
+    }
+
+    return {
+      gameId: data.gameId,
+      startedAt: new Date(data.startedAt),
+      finishedAt: data.finishedAt ? new Date(data.finishedAt) : null,
+      createdBy: parseInt(data.createdBy),
+      duration: data.duration ? parseInt(data.duration) : null,
+      totalPlayers: data.totalPlayers ? parseInt(data.totalPlayers) : null,
+      gameMode: (data.gameMode as GameMode) ?? null,
+      totalRounds: data.totalRounds ? parseInt(data.totalRounds) : null,
+      totalQuestions: data.totalQuestions
+        ? parseInt(data.totalQuestions)
+        : null,
+    };
+  }
+
+  /**
+   * Update live game statistics
+   */
+  public async updateLiveStatistics(
+    gameStats: GameStatisticsData,
+    updates: Partial<GameStatisticsData>
+  ): Promise<void> {
+    const updated: GameStatisticsData = {
+      ...gameStats,
+      ...updates,
+    };
+
+    const key = this._getRedisKey(gameStats.gameId);
+    await this.redisService.hset(key, updated, GAME_STATISTICS_TTL); // 24 hours TTL
+  }
+
+  /**
+   * Delete live game statistics from Redis after persistence
+   */
+  public async deleteLiveStatistics(gameId: string): Promise<void> {
+    const key = this._getRedisKey(gameId);
+    await this.redisService.del(key);
+  }
+
+  /**
+   * Create persistent game statistics in database when game finishes
+   */
+  public async createPersistentStatistics(
+    data: GameStatisticsData
+  ): Promise<GameStatistics> {
+    const gameStats = new GameStatistics();
+    gameStats.import(data);
+
+    return this.repository.save(gameStats);
+  }
+
+  /**
+   * Get persistent game statistics from database by game ID
+   */
+  public async getPersistentStatistics(
+    gameId: string
+  ): Promise<GameStatistics | null> {
+    return this.repository.findOne({
+      where: { game_id: gameId },
+    });
+  }
+
+  /**
+   * Get all persistent game statistics for a user from database
+   */
+  public async getPersistentStatisticsByUser(
+    userId: number
+  ): Promise<GameStatistics[]> {
+    return this.repository.find({
+      where: { created_by: userId },
+      order: { created_at: "DESC" },
+    });
+  }
+
+  /**
+   * Update persistent game statistics in database (rare operation)
+   */
+  public async updatePersistentStatistics(
+    gameId: string,
+    updates: Partial<GameStatisticsData>
+  ): Promise<GameStatistics | null> {
+    const existing = await this.getPersistentStatistics(gameId);
+    if (!existing) {
+      return null;
+    }
+
+    // Update the entity with new values
+    Object.assign(existing, updates);
+
+    return this.repository.save(existing);
+  }
+
+  /**
+   * Delete persistent game statistics from database (rare operation)
+   */
+  public async deletePersistentStatistics(gameId: string): Promise<boolean> {
+    const result = await this.repository.delete({ game_id: gameId });
+    return (result.affected ?? 0) > 0;
+  }
+
+  /**
+   * Generate Redis key for game statistics
+   */
+  private _getRedisKey(gameId: string): string {
+    return `${GAME_STATISTICS_REDIS_NSP}:${gameId}`;
+  }
+}

--- a/server/src/infrastructure/database/repositories/statistics/PlayerGameStatsRepository.ts
+++ b/server/src/infrastructure/database/repositories/statistics/PlayerGameStatsRepository.ts
@@ -1,0 +1,172 @@
+import { Repository } from "typeorm";
+
+import {
+  PLAYER_STATISTICS_REDIS_NSP,
+  PLAYER_STATISTICS_TTL,
+} from "domain/constants/statistics";
+import { PlayerGameStatsData } from "domain/types/statistics/PlayerGameStatsData";
+import { PlayerGameStats } from "infrastructure/database/models/statistics/PlayerGameStats";
+import { RedisService } from "infrastructure/services/redis/RedisService";
+
+/**
+ * Repository for player game statistics persistence operations
+ */
+export class PlayerGameStatsRepository {
+  constructor(
+    private readonly repository: Repository<PlayerGameStats>,
+    private readonly redisService: RedisService
+  ) {
+    //
+  }
+
+  /**
+   * Initialize player session in Redis for live tracking
+   */
+  public async initializeStats(
+    gameId: string,
+    userId: number,
+    sessionData: Record<string, unknown>
+  ): Promise<void> {
+    const key = this._getStatsRedisKey(gameId, userId);
+    await this.redisService.hset(key, sessionData, PLAYER_STATISTICS_TTL);
+  }
+
+  /**
+   * Update player session data in Redis
+   */
+  public async updateStats(
+    gameId: string,
+    userId: number,
+    updates: Record<string, any>
+  ): Promise<void> {
+    const key = this._getStatsRedisKey(gameId, userId);
+    await this.redisService.hset(key, updates, PLAYER_STATISTICS_TTL);
+  }
+
+  /**
+   * Get player session data from Redis
+   */
+  public async getStats(
+    gameId: string,
+    userId: number
+  ): Promise<Record<string, any> | null> {
+    const key = this._getStatsRedisKey(gameId, userId);
+    const data = await this.redisService.hgetall(key);
+
+    if (!data || Object.keys(data).length === 0) {
+      return null;
+    }
+
+    return data;
+  }
+
+  /**
+   * Delete player session from Redis
+   */
+  public async deleteStats(gameId: string, userId: number): Promise<void> {
+    const key = this._getStatsRedisKey(gameId, userId);
+    await this.redisService.del(key);
+  }
+
+  /**
+   * Save player game statistics to database
+   */
+  public async save(data: PlayerGameStatsData): Promise<PlayerGameStats> {
+    const entity = new PlayerGameStats();
+    entity.import(data);
+
+    return this.repository.save(entity);
+  }
+
+  /**
+   * Save multiple player game statistics to database
+   */
+  public async saveMany(
+    dataList: PlayerGameStatsData[]
+  ): Promise<PlayerGameStats[]> {
+    const entities = dataList.map((data) => {
+      const entity = new PlayerGameStats();
+      entity.import(data);
+      return entity;
+    });
+
+    return this.repository.save(entities);
+  }
+
+  /**
+   * Get player game statistics by game statistics ID
+   */
+  public async getByGameStatsId(
+    gameStatsId: number
+  ): Promise<PlayerGameStats[]> {
+    return this.repository.find({
+      where: { game_stats_id: gameStatsId },
+      relations: ["user"],
+      order: { placement: "ASC" },
+    });
+  }
+
+  /**
+   * Get player game statistics by user ID
+   */
+  public async getByUserId(
+    userId: number,
+    limit = 50
+  ): Promise<PlayerGameStats[]> {
+    return this.repository.find({
+      where: { user_id: userId },
+      relations: ["gameStats"],
+      order: { created_at: "DESC" },
+      take: limit,
+    });
+  }
+
+  /**
+   * Get player statistics for a specific game and user
+   */
+  public async getByGameAndUser(
+    gameStatsId: number,
+    userId: number
+  ): Promise<PlayerGameStats | null> {
+    return this.repository.findOne({
+      where: {
+        game_stats_id: gameStatsId,
+        user_id: userId,
+      },
+      relations: ["user", "gameStats"],
+    });
+  }
+
+  /**
+   * Calculate player rankings/placements for a game
+   */
+  public async updatePlacements(gameStatsId: number): Promise<void> {
+    // Get all players for this game sorted by final score (descending)
+    const playerStats = await this.repository.find({
+      where: { game_stats_id: gameStatsId },
+      order: { final_score: "DESC" },
+    });
+
+    // Assign placements based on score ranking
+    for (let i = 0; i < playerStats.length; i++) {
+      const player = playerStats[i];
+      let placement = i + 1;
+
+      // Handle ties - players with same score get same placement
+      if (i > 0 && playerStats[i - 1].final_score === player.final_score) {
+        placement = playerStats[i - 1].placement!;
+      }
+
+      player.placement = placement;
+    }
+
+    await this.repository.save(playerStats);
+  }
+
+  /**
+   * Generate Redis key for player session data
+   */
+  private _getStatsRedisKey(gameId: string, userId: number): string {
+    return `${PLAYER_STATISTICS_REDIS_NSP}:${gameId}:${userId}`;
+  }
+}

--- a/server/src/presentation/ServeApi.ts
+++ b/server/src/presentation/ServeApi.ts
@@ -6,6 +6,7 @@ import { type Server as IOServer } from "socket.io";
 import { DIConfig } from "application/config/DIConfig";
 import { Container, CONTAINER_TYPES } from "application/Container";
 import { type ApiContext } from "application/context/ApiContext";
+import { StatisticsWorkerFactory } from "application/factories/StatisticsWorkerFactory";
 import { FileService } from "application/services/file/FileService";
 import { GameService } from "application/services/game/GameService";
 import { PackageService } from "application/services/package/PackageService";
@@ -14,6 +15,7 @@ import { SocketIOChatService } from "application/services/socket/SocketIOChatSer
 import { SocketIOGameService } from "application/services/socket/SocketIOGameService";
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
 import { UserNotificationRoomService } from "application/services/socket/UserNotificationRoomService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
 import { UserService } from "application/services/user/UserService";
 import { SESSION_SECRET_LENGTH } from "domain/constants/session";
 import { SOCKET_GAME_NAMESPACE } from "domain/constants/socket";
@@ -165,6 +167,13 @@ export class ServeApi {
       userNotificationRoomService: Container.get<UserNotificationRoomService>(
         CONTAINER_TYPES.UserNotificationRoomService
       ),
+      statisticsWorkerFactory: Container.get<StatisticsWorkerFactory>(
+        CONTAINER_TYPES.StatisticsWorkerFactory
+      ),
+      gameStatisticsCollectorService:
+        Container.get<GameStatisticsCollectorService>(
+          CONTAINER_TYPES.GameStatisticsCollectorService
+        ),
     };
 
     // REST
@@ -208,6 +217,7 @@ export class ServeApi {
       deps.socketIOQuestionService,
       deps.finalRoundService,
       deps.userNotificationRoomService,
+      deps.gameStatisticsCollectorService,
       this._context.logger
     );
   }

--- a/server/src/presentation/controllers/io/SocketIOInitializer.ts
+++ b/server/src/presentation/controllers/io/SocketIOInitializer.ts
@@ -5,6 +5,7 @@ import { SocketIOChatService } from "application/services/socket/SocketIOChatSer
 import { SocketIOGameService } from "application/services/socket/SocketIOGameService";
 import { SocketIOQuestionService } from "application/services/socket/SocketIOQuestionService";
 import { UserNotificationRoomService } from "application/services/socket/UserNotificationRoomService";
+import { GameStatisticsCollectorService } from "application/services/statistics/GameStatisticsCollectorService";
 import { SOCKET_GAME_NAMESPACE } from "domain/constants/socket";
 import { SocketIOEvents } from "domain/enums/SocketIOEvents";
 import { SocketEventHandlerFactory } from "domain/handlers/socket/SocketEventHandlerFactory";
@@ -24,6 +25,7 @@ export class SocketIOInitializer {
     private readonly socketIOQuestionService: SocketIOQuestionService,
     private readonly finalRoundService: FinalRoundService,
     private readonly userNotificationRoomService: UserNotificationRoomService,
+    private readonly gameStatisticsCollectorService: GameStatisticsCollectorService,
     private readonly logger: ILogger
   ) {
     this.handlerFactory = new SocketEventHandlerFactory(
@@ -33,6 +35,7 @@ export class SocketIOInitializer {
       this.finalRoundService,
       this.userNotificationRoomService,
       this.socketIOQuestionService,
+      this.gameStatisticsCollectorService,
       this.logger
     );
 

--- a/server/src/presentation/schemes/game/gameSchemes.ts
+++ b/server/src/presentation/schemes/game/gameSchemes.ts
@@ -1,12 +1,14 @@
 import Joi from "joi";
 
 import {
+  GAME_ID_CHARACTERS_LENGTH,
   GAME_MAX_PLAYERS,
   GAME_TITLE_MAX_CHARS,
   GAME_TITLE_MIN_CHARS,
 } from "domain/constants/game";
 import { LIMIT_MAX, LIMIT_MIN, OFFSET_MIN } from "domain/constants/pagination";
 import { AgeRestriction } from "domain/enums/game/AgeRestriction";
+import { GameRedisHashDTO } from "domain/types/dto/game/GameRedisHashDTO";
 import { GamePaginationOpts } from "domain/types/pagination/game/GamePaginationOpts";
 import { PaginationOrder } from "domain/types/pagination/PaginationOpts";
 
@@ -43,4 +45,32 @@ export const gamePaginationScheme = () =>
     createdAtMin: Joi.date().optional(),
     isPrivate: Joi.boolean().optional(),
     titlePrefix: Joi.string().optional(),
+  });
+
+/**
+ * Joi schema for validating Game Redis data
+ * All values in Redis are strings, so we validate string formats
+ */
+export const gameRedisDataScheme = () =>
+  Joi.object<GameRedisHashDTO>({
+    id: Joi.string().length(GAME_ID_CHARACTERS_LENGTH).required(),
+    createdBy: Joi.string().pattern(/^\d+$/).required(), // Numeric string
+    title: Joi.string().min(1).max(255).required(),
+    createdAt: Joi.string().pattern(/^\d+$/).required(), // Timestamp string
+    isPrivate: Joi.string().valid("0", "1").required(), // Boolean as string
+    ageRestriction: Joi.string()
+      .valid(...Object.values(AgeRestriction))
+      .required(),
+    players: Joi.string().required(),
+    maxPlayers: Joi.string().pattern(/^\d+$/).required(), // Numeric string
+    startedAt: Joi.alternatives()
+      .try(Joi.string().allow(""), Joi.date().iso())
+      .optional(),
+    finishedAt: Joi.alternatives()
+      .try(Joi.string().allow(""), Joi.date().iso())
+      .optional(),
+    package: Joi.string().required(),
+    roundsCount: Joi.string().pattern(/^\d+$/).required(), // Numeric string
+    questionsCount: Joi.string().pattern(/^\d+$/).required(), // Numeric string
+    gameState: Joi.string().required(),
   });

--- a/server/src/presentation/schemes/game/playerSchemes.ts
+++ b/server/src/presentation/schemes/game/playerSchemes.ts
@@ -1,0 +1,22 @@
+import { PlayerGameStatsRedisData } from "domain/types/statistics/PlayerGameStatsRedisData";
+import Joi from "joi";
+
+/**
+ * Joi schema for validating PlayerGameStats Redis data
+ * All values in Redis are strings, so we validate string formats
+ */
+export const playerGameStatsDataScheme = () =>
+  Joi.object<PlayerGameStatsRedisData>({
+    gameId: Joi.string().required(),
+    userId: Joi.string().pattern(/^\d+$/).required(), // Numeric string
+    joinedAt: Joi.string().isoDate().required(), // ISO date string
+    leftAt: Joi.alternatives()
+      .try(Joi.string().isoDate(), Joi.string().allow(""))
+      .optional(),
+    currentScore: Joi.string()
+      .pattern(/^-?\d+$/)
+      .required(), // Numeric string (can be negative)
+    questionsAnswered: Joi.string().pattern(/^\d+$/).required(), // Non-negative numeric string
+    correctAnswers: Joi.string().pattern(/^\d+$/).required(), // Non-negative numeric string
+    wrongAnswers: Joi.string().pattern(/^\d+$/).required(), // Non-negative numeric string
+  });

--- a/server/tests/TestEnvironment.ts
+++ b/server/tests/TestEnvironment.ts
@@ -56,7 +56,8 @@ export class TestEnvironment {
   private _getPGClient() {
     const client = new Client({
       user: process.env.DB_USER || "postgres",
-      password: process.env.DB_PASS || "postgres",
+      // password: process.env.DB_PASS || "postgres",
+      password: process.env.DB_PASS || "Asdf1234!",
       host: process.env.DB_HOST || "127.0.0.1",
       port: parseInt(process.env.DB_PORT || "5432", 10),
     });

--- a/server/tests/socket/game/question/HiddenQuestionFlow.test.ts
+++ b/server/tests/socket/game/question/HiddenQuestionFlow.test.ts
@@ -252,9 +252,10 @@ describe("Hidden Question Flow Tests", () => {
         const initialGameState = await utils.getGameState(gameId);
 
         // Find all hidden questions
-        const hiddenQuestions = utils.findAllQuestionsByType(
+        const hiddenQuestions = await utils.findAllQuestionsByType(
           initialGameState!,
-          PackageQuestionType.HIDDEN
+          PackageQuestionType.HIDDEN,
+          gameId
         );
 
         if (hiddenQuestions.length < 2) {
@@ -289,9 +290,10 @@ describe("Hidden Question Flow Tests", () => {
         expect(afterFirstState!.questionState).toBe(QuestionState.CHOOSING);
 
         // Check that remaining hidden questions still have null price in game state
-        const remainingHiddenQuestions = utils.findAllQuestionsByType(
+        const remainingHiddenQuestions = await utils.findAllQuestionsByType(
           afterFirstState!,
-          PackageQuestionType.HIDDEN
+          PackageQuestionType.HIDDEN,
+          gameId
         );
 
         const unplayedHiddenQuestion = remainingHiddenQuestions.find(

--- a/server/tests/socket/game/statistics/GameStatisticsPersistence.test.ts
+++ b/server/tests/socket/game/statistics/GameStatisticsPersistence.test.ts
@@ -1,0 +1,240 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+import { type Express } from "express";
+import { Repository } from "typeorm";
+
+import { SocketIOGameEvents } from "domain/enums/SocketIOEvents";
+import { AnswerResultType } from "domain/types/socket/game/AnswerResultData";
+import { RedisConfig } from "infrastructure/config/RedisConfig";
+import { User } from "infrastructure/database/models/User";
+import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
+import { ILogger } from "infrastructure/logger/ILogger";
+import { PinoLogger } from "infrastructure/logger/PinoLogger";
+import { bootstrapTestApp } from "tests/TestApp";
+import { TestEnvironment } from "tests/TestEnvironment";
+import { SocketGameTestUtils } from "tests/socket/game/utils/SocketIOGameTestUtils";
+
+describe("Game Statistics Persistence Tests", () => {
+  let testEnv: TestEnvironment;
+  let cleanup: (() => Promise<void>) | undefined;
+  let _app: Express;
+  let userRepo: Repository<User>;
+  let gameStatsRepo: Repository<GameStatistics>;
+  let serverUrl: string;
+  let utils: SocketGameTestUtils;
+  let logger: ILogger;
+
+  beforeAll(async () => {
+    logger = await PinoLogger.init({ pretty: true });
+    testEnv = new TestEnvironment(logger);
+    await testEnv.setup();
+    const boot = await bootstrapTestApp(testEnv.getDatabase());
+    _app = boot.app;
+    userRepo = testEnv.getDatabase().getRepository(User);
+    gameStatsRepo = testEnv.getDatabase().getRepository(GameStatistics);
+    cleanup = boot.cleanup;
+    serverUrl = `http://localhost:${process.env.PORT || 3000}`;
+    utils = new SocketGameTestUtils(serverUrl);
+  });
+
+  beforeEach(async () => {
+    // Clear Redis before each test
+    const redisClient = RedisConfig.getClient();
+    const keys = await redisClient.keys("*");
+    if (keys.length > 0) {
+      await redisClient.del(...keys);
+    }
+    await gameStatsRepo.clear();
+  });
+
+  afterAll(async () => {
+    try {
+      await testEnv.teardown();
+      if (cleanup) await cleanup();
+    } catch (err) {
+      console.error("Error during teardown:", err);
+    }
+  });
+
+  it("should record statistics to database when game ends", async () => {
+    // Setup game with 1 player
+    const setup = await utils.setupGameTestEnvironment(userRepo, _app, 1, 0);
+    const { showmanSocket, playerSockets } = setup;
+
+    try {
+      // Start game
+      await utils.startGame(showmanSocket);
+
+      // Wait for game to finish
+      const gameFinishedPromise = new Promise((resolve) => {
+        playerSockets[0].on(SocketIOGameEvents.NEXT_ROUND, () => {
+          showmanSocket.emit(SocketIOGameEvents.NEXT_ROUND, {});
+        });
+
+        playerSockets[0].on(SocketIOGameEvents.GAME_FINISHED, (data) => {
+          resolve(data);
+        });
+      });
+
+      // Start the game finish sequence by emitting first NEXT_ROUND
+      showmanSocket.emit(SocketIOGameEvents.NEXT_ROUND, {});
+
+      // Wait for game finish event
+      const gameFinishedData = await gameFinishedPromise;
+      expect(gameFinishedData).toBe(true);
+
+      // Now verify statistics were recorded to database
+      const savedStats = await gameStatsRepo.find();
+
+      expect(savedStats).toBeDefined();
+      expect(savedStats.length).toBeGreaterThan(0);
+
+      const gameStats = savedStats[0];
+      expect(gameStats.started_at).toBeDefined();
+      expect(gameStats.finished_at).toBeDefined();
+      expect(gameStats.duration).toBeGreaterThan(0);
+      expect(gameStats.created_by).toBeDefined();
+    } finally {
+      // Cleanup sockets
+      showmanSocket.disconnect();
+      playerSockets.forEach((socket) => socket.disconnect());
+    }
+  });
+
+  it("should record statistics to database when game ends via answer result", async () => {
+    // Setup game with 1 player
+    const setup = await utils.setupGameTestEnvironment(userRepo, _app, 1, 0);
+    const { showmanSocket, playerSockets } = setup;
+
+    try {
+      // Start game
+      await utils.startGame(showmanSocket);
+
+      // Wait for game to finish via answer result instead of next round
+      const gameFinishedPromise = new Promise((resolve) => {
+        let nextRoundCount = 0;
+
+        playerSockets[0].on(SocketIOGameEvents.NEXT_ROUND, async () => {
+          nextRoundCount++;
+          if (nextRoundCount === 1) {
+            // First next round - advance to final round
+            showmanSocket.emit(SocketIOGameEvents.NEXT_ROUND, {});
+          } else {
+            // Instead of second next round that would end game, use answer-result
+            // First need to pick a question to have a valid questionId for answer-result
+            let finalQuestionId: number = 0;
+
+            showmanSocket.once(
+              SocketIOGameEvents.QUESTION_DATA,
+              (questionData) => {
+                finalQuestionId = questionData.id;
+
+                // Then emit answer-result to end the game
+                showmanSocket.emit(SocketIOGameEvents.ANSWER_RESULT, {
+                  questionId: finalQuestionId,
+                  answerType: AnswerResultType.CORRECT,
+                  scoreResult: 100,
+                });
+              }
+            );
+
+            // Pick a question in final round to get valid questionId
+            await utils.pickQuestion(showmanSocket);
+          }
+        });
+
+        playerSockets[0].on(SocketIOGameEvents.GAME_FINISHED, (data) => {
+          resolve(data);
+        });
+      });
+
+      // Start the game finish sequence by emitting first NEXT_ROUND
+      showmanSocket.emit(SocketIOGameEvents.NEXT_ROUND, {});
+
+      // Wait for game finish event
+      const gameFinishedData = await gameFinishedPromise;
+      expect(gameFinishedData).toBe(true);
+
+      // Now verify statistics were recorded to database
+      const savedStats = await gameStatsRepo.find();
+
+      expect(savedStats).toBeDefined();
+      expect(savedStats.length).toBeGreaterThan(0);
+
+      const gameStats = savedStats[0];
+      expect(gameStats.started_at).toBeDefined();
+      expect(gameStats.finished_at).toBeDefined();
+      expect(gameStats.duration).toBeGreaterThan(0);
+      expect(gameStats.created_by).toBeDefined();
+    } finally {
+      // Cleanup sockets
+      showmanSocket.disconnect();
+      playerSockets.forEach((socket) => socket.disconnect());
+    }
+  });
+
+  it("should record statistics to database when game ends via skip question force", async () => {
+    // Setup game with 1 player
+    const setup = await utils.setupGameTestEnvironment(userRepo, _app, 1, 0);
+    const { showmanSocket, playerSockets } = setup;
+
+    try {
+      // Start game
+      await utils.startGame(showmanSocket);
+
+      // Skip first round to get to final round
+      showmanSocket.emit(SocketIOGameEvents.NEXT_ROUND, {});
+
+      // Wait for game to finish via skipping all questions in final round
+      const gameFinishedPromise = new Promise((resolve) => {
+        playerSockets[0].on(SocketIOGameEvents.GAME_FINISHED, (data) => {
+          resolve(data);
+        });
+
+        // TODO: This will break when we add server-side timer for question results showing
+        // * We wont't be able to pick question while previous one is showing answer
+        const skipAllQuestions = async () => {
+          try {
+            // Pick question then immediately skip it
+            await utils.pickQuestion(showmanSocket);
+            showmanSocket.emit(SocketIOGameEvents.SKIP_QUESTION_FORCE, {});
+
+            // Continue skipping questions until all are done
+            setTimeout(skipAllQuestions, 100);
+          } catch {
+            // If we can't pick more questions, the game should finish soon
+          }
+        };
+
+        // Start skipping questions after a short delay
+        setTimeout(skipAllQuestions, 100);
+      });
+
+      // Wait for game finish event
+      const gameFinishedData = await gameFinishedPromise;
+      expect(gameFinishedData).toBe(true);
+
+      // Verify statistics were recorded to database
+      const savedStats = await gameStatsRepo.find();
+
+      expect(savedStats).toBeDefined();
+      expect(savedStats.length).toBeGreaterThan(0);
+
+      const gameStats = savedStats[0];
+      expect(gameStats.started_at).toBeDefined();
+      expect(gameStats.finished_at).toBeDefined();
+      expect(gameStats.duration).toBeGreaterThan(0);
+      expect(gameStats.created_by).toBeDefined();
+    } finally {
+      // Cleanup sockets
+      showmanSocket.disconnect();
+      playerSockets.forEach((socket) => socket.disconnect());
+    }
+  });
+});

--- a/server/tests/socket/game/statistics/PlayerGameStats.test.ts
+++ b/server/tests/socket/game/statistics/PlayerGameStats.test.ts
@@ -10,8 +10,10 @@ import { type Express } from "express";
 import { Repository } from "typeorm";
 
 import { Container, CONTAINER_TYPES } from "application/Container";
+import { PackageQuestionType } from "domain/enums/package/QuestionType";
 import { SocketIOGameEvents } from "domain/enums/SocketIOEvents";
 import { PlayerRole } from "domain/types/game/PlayerRole";
+import { AnswerResultType } from "domain/types/socket/game/AnswerResultData";
 import { RedisConfig } from "infrastructure/config/RedisConfig";
 import { User } from "infrastructure/database/models/User";
 import { PlayerGameStatsRepository } from "infrastructure/database/repositories/statistics/PlayerGameStatsRepository";
@@ -506,6 +508,413 @@ describe("Player Game Statistics Tests", () => {
         const backToPlayerSessionData =
           await playerGameStatsRepository.getStats(gameId, playerId);
         expect(backToPlayerSessionData!.leftAt).toBe("");
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+
+  describe("Player Answer Statistics Tracking", () => {
+    it("should increment correct answers and questions answered when player answers correctly", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 2, 1);
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const playerId = setup.playerUsers[0].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        // Pick and display a question
+        await utils.pickQuestion(showmanSocket);
+
+        // Get initial stats before answering
+        const initialStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        const initialQuestionsAnswered = parseInt(
+          initialStats!.questionsAnswered || "0"
+        );
+        const initialCorrectAnswers = parseInt(
+          initialStats!.correctAnswers || "0"
+        );
+        const initialWrongAnswers = parseInt(initialStats!.wrongAnswers || "0");
+
+        // Player answers the question
+        await utils.answerQuestion(playerSockets[0], showmanSocket);
+
+        // Showman marks answer as correct
+        const answerResultPromise = utils.waitForEvent(
+          playerSockets[0],
+          SocketIOGameEvents.ANSWER_RESULT
+        );
+        showmanSocket.emit(SocketIOGameEvents.ANSWER_RESULT, {
+          scoreResult: 100,
+          answerType: AnswerResultType.CORRECT,
+        });
+        await answerResultPromise;
+
+        // Verify statistics were updated correctly
+        const updatedStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(updatedStats).toBeTruthy();
+        expect(parseInt(updatedStats!.questionsAnswered)).toBe(
+          initialQuestionsAnswered + 1
+        );
+        expect(parseInt(updatedStats!.correctAnswers)).toBe(
+          initialCorrectAnswers + 1
+        );
+        expect(parseInt(updatedStats!.wrongAnswers)).toBe(initialWrongAnswers); // Should remain unchanged
+        expect(parseInt(updatedStats!.currentScore)).toBeGreaterThan(0); // Score should increase
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should increment wrong answers and questions answered when player answers incorrectly", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 2, 1);
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const playerId = setup.playerUsers[0].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        // Pick and display a question
+        await utils.pickQuestion(showmanSocket);
+
+        // Get initial stats before answering
+        const initialStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        const initialQuestionsAnswered = parseInt(
+          initialStats!.questionsAnswered || "0"
+        );
+        const initialCorrectAnswers = parseInt(
+          initialStats!.correctAnswers || "0"
+        );
+        const initialWrongAnswers = parseInt(initialStats!.wrongAnswers || "0");
+        const initialScore = parseInt(initialStats!.currentScore || "0");
+
+        // Player answers the question
+        await utils.answerQuestion(playerSockets[0], showmanSocket);
+
+        // Showman marks answer as wrong
+        const answerResultPromise = utils.waitForEvent(
+          playerSockets[0],
+          SocketIOGameEvents.ANSWER_RESULT
+        );
+        showmanSocket.emit(SocketIOGameEvents.ANSWER_RESULT, {
+          scoreResult: -100,
+          answerType: AnswerResultType.WRONG,
+        });
+        await answerResultPromise;
+
+        // Verify statistics were updated correctly
+        const updatedStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(updatedStats).toBeTruthy();
+        expect(parseInt(updatedStats!.questionsAnswered)).toBe(
+          initialQuestionsAnswered + 1
+        );
+        expect(parseInt(updatedStats!.correctAnswers)).toBe(
+          initialCorrectAnswers
+        ); // Should remain unchanged
+        expect(parseInt(updatedStats!.wrongAnswers)).toBe(
+          initialWrongAnswers + 1
+        );
+        expect(parseInt(updatedStats!.currentScore)).toBe(initialScore - 100); // Score should decrease
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should track multiple answers correctly for single player", async () => {
+      const setup = await utils.setupGameTestEnvironment(
+        userRepo,
+        app,
+        2,
+        1,
+        false,
+        2
+      );
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const playerId = setup.playerUsers[0].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        // Get initial stats
+        const initialStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        let questionsAnswered = parseInt(
+          initialStats!.questionsAnswered || "0"
+        );
+        let correctAnswers = parseInt(initialStats!.correctAnswers || "0");
+        let wrongAnswers = parseInt(initialStats!.wrongAnswers || "0");
+
+        const gameState = await utils.getGameState(setup.gameId);
+
+        expect(gameState).toBeDefined();
+
+        const simpleQuestions = await utils.findAllQuestionsByType(
+          gameState!,
+          PackageQuestionType.SIMPLE,
+          gameId
+        );
+
+        if (simpleQuestions.length < 3) {
+          throw new Error("Not enough simple questions for this test");
+        }
+        // Answer first question correctly using pickAndCompleteQuestion
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          simpleQuestions[0].id,
+          true,
+          AnswerResultType.CORRECT
+        );
+
+        // Verify first correct answer
+        let stats = await playerGameStatsRepository.getStats(gameId, playerId);
+        expect(parseInt(stats!.questionsAnswered)).toBe(questionsAnswered + 1);
+        expect(parseInt(stats!.correctAnswers)).toBe(correctAnswers + 1);
+        expect(parseInt(stats!.wrongAnswers)).toBe(wrongAnswers);
+
+        // Update our tracking variables
+        questionsAnswered++;
+        correctAnswers++;
+
+        // Answer second question incorrectly
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          simpleQuestions[1].id,
+          true,
+          AnswerResultType.WRONG,
+          -50
+        );
+
+        // Verify second wrong answer
+        stats = await playerGameStatsRepository.getStats(gameId, playerId);
+        expect(parseInt(stats!.questionsAnswered)).toBe(questionsAnswered + 1);
+        expect(parseInt(stats!.correctAnswers)).toBe(correctAnswers);
+        expect(parseInt(stats!.wrongAnswers)).toBe(wrongAnswers + 1);
+
+        // Update our tracking variables
+        questionsAnswered++;
+        wrongAnswers++;
+
+        // Skip the current wrong answer display and answer third question correctly
+        await utils.skipQuestion(showmanSocket);
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          simpleQuestions[2].id,
+          true
+        );
+
+        // Verify final statistics: 3 total, 2 correct, 1 wrong
+        const finalStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(parseInt(finalStats!.questionsAnswered)).toBe(
+          questionsAnswered + 1
+        );
+        expect(parseInt(finalStats!.correctAnswers)).toBe(correctAnswers + 1);
+        expect(parseInt(finalStats!.wrongAnswers)).toBe(wrongAnswers);
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should track statistics independently for multiple players", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 3, 1);
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const player1Id = setup.playerUsers[0].id;
+      const player2Id = setup.playerUsers[1].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        // Player 1 answers correctly using pickAndCompleteQuestion
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          undefined,
+          true
+        );
+
+        // Player 2 answers incorrectly on next question using enhanced method
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          [playerSockets[1]], // Only player 2 answers
+          undefined,
+          true,
+          AnswerResultType.WRONG,
+          -50
+        );
+
+        // Verify Player 1 stats (1 correct, 0 wrong)
+        const player1Stats = await playerGameStatsRepository.getStats(
+          gameId,
+          player1Id
+        );
+        expect(parseInt(player1Stats!.questionsAnswered)).toBe(1);
+        expect(parseInt(player1Stats!.correctAnswers)).toBe(1);
+        expect(parseInt(player1Stats!.wrongAnswers)).toBe(0);
+
+        // Verify Player 2 stats (0 correct, 1 wrong)
+        const player2Stats = await playerGameStatsRepository.getStats(
+          gameId,
+          player2Id
+        );
+        expect(parseInt(player2Stats!.questionsAnswered)).toBe(1);
+        expect(parseInt(player2Stats!.correctAnswers)).toBe(0);
+        expect(parseInt(player2Stats!.wrongAnswers)).toBe(1);
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+
+  describe("Skip Answer Handling", () => {
+    it("should not count skipped questions as wrong answers", async () => {
+      const setup = await utils.setupGameTestEnvironment(
+        userRepo,
+        app,
+        2,
+        1,
+        false,
+        2
+      );
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const playerId = setup.playerUsers[0].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        // Get initial stats
+        const initialStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        const initialQuestionsAnswered = parseInt(
+          initialStats!.questionsAnswered || "0"
+        );
+        const initialCorrectAnswers = parseInt(
+          initialStats!.correctAnswers || "0"
+        );
+        const initialWrongAnswers = parseInt(initialStats!.wrongAnswers || "0");
+
+        const simpleQuestionId = await utils.getQuestionIdByType(
+          gameId,
+          PackageQuestionType.SIMPLE
+        );
+
+        // Pick and display a question
+        await utils.pickQuestion(showmanSocket, simpleQuestionId);
+
+        // Player answers the question
+        await utils.answerQuestion(playerSockets[0], showmanSocket);
+
+        // Showman marks answer as skip (0x)
+        const answerResultPromise = utils.waitForEvent(
+          playerSockets[0],
+          SocketIOGameEvents.ANSWER_RESULT
+        );
+        showmanSocket.emit(SocketIOGameEvents.ANSWER_RESULT, {
+          scoreResult: 0,
+          answerType: AnswerResultType.SKIP,
+        });
+        await answerResultPromise;
+
+        // Verify statistics: questions answered increased, but wrong answers did not
+        const updatedStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(updatedStats).toBeTruthy();
+        expect(parseInt(updatedStats!.questionsAnswered)).toBe(
+          initialQuestionsAnswered + 1
+        );
+        // Should remain unchanged
+        expect(parseInt(updatedStats!.correctAnswers)).toBe(
+          initialCorrectAnswers
+        );
+        // Should remain unchanged for SKIP
+        expect(parseInt(updatedStats!.wrongAnswers)).toBe(initialWrongAnswers);
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should handle mixed answer types correctly", async () => {
+      const setup = await utils.setupGameTestEnvironment(
+        userRepo,
+        app,
+        2,
+        1,
+        false,
+        2
+      );
+      const { playerSockets, showmanSocket, gameId } = setup;
+      const playerId = setup.playerUsers[0].id;
+
+      try {
+        // Start the game
+        await utils.startGame(showmanSocket);
+
+        const gameState = await utils.getGameState(setup.gameId);
+        const simpleQuestions = await utils.findAllQuestionsByType(
+          gameState!,
+          PackageQuestionType.SIMPLE,
+          gameId
+        );
+
+        if (simpleQuestions.length < 3) {
+          throw new Error("Not enough simple questions for this test");
+        }
+
+        // Answer first question correctly
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          simpleQuestions[0].id,
+          true,
+          AnswerResultType.CORRECT,
+          100
+        );
+
+        // Answer second question as skip
+        await utils.pickAndCompleteQuestion(
+          showmanSocket,
+          playerSockets,
+          simpleQuestions[1].id,
+          true,
+          AnswerResultType.SKIP,
+          0
+        );
+
+        // Verify final statistics: 2 questions, 1 correct, 0 wrong, 0 skip counted as wrong
+        const finalStats = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(parseInt(finalStats!.questionsAnswered)).toBe(2);
+        expect(parseInt(finalStats!.correctAnswers)).toBe(1);
+        expect(parseInt(finalStats!.wrongAnswers)).toBe(0);
       } finally {
         await utils.cleanupGameClients(setup);
       }

--- a/server/tests/socket/game/statistics/PlayerGameStats.test.ts
+++ b/server/tests/socket/game/statistics/PlayerGameStats.test.ts
@@ -1,0 +1,514 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+import { type Express } from "express";
+import { Repository } from "typeorm";
+
+import { Container, CONTAINER_TYPES } from "application/Container";
+import { SocketIOGameEvents } from "domain/enums/SocketIOEvents";
+import { PlayerRole } from "domain/types/game/PlayerRole";
+import { RedisConfig } from "infrastructure/config/RedisConfig";
+import { User } from "infrastructure/database/models/User";
+import { PlayerGameStatsRepository } from "infrastructure/database/repositories/statistics/PlayerGameStatsRepository";
+import { ILogger } from "infrastructure/logger/ILogger";
+import { PinoLogger } from "infrastructure/logger/PinoLogger";
+import {
+  GameClientSocket,
+  SocketGameTestUtils,
+} from "tests/socket/game/utils/SocketIOGameTestUtils";
+import { bootstrapTestApp } from "tests/TestApp";
+import { TestEnvironment } from "tests/TestEnvironment";
+
+describe("Player Game Statistics Tests", () => {
+  let testEnv: TestEnvironment;
+  let cleanup: (() => Promise<void>) | undefined;
+  let app: Express;
+  let userRepo: Repository<User>;
+  let serverUrl: string;
+  let utils: SocketGameTestUtils;
+  let logger: ILogger;
+  let playerGameStatsRepository: PlayerGameStatsRepository;
+
+  beforeAll(async () => {
+    logger = await PinoLogger.init({ pretty: true });
+    testEnv = new TestEnvironment(logger);
+    await testEnv.setup();
+    const boot = await bootstrapTestApp(testEnv.getDatabase());
+    app = boot.app;
+    userRepo = testEnv.getDatabase().getRepository(User);
+    cleanup = boot.cleanup;
+    serverUrl = `http://localhost:${process.env.PORT || 3000}`;
+    utils = new SocketGameTestUtils(serverUrl);
+
+    playerGameStatsRepository = Container.get<PlayerGameStatsRepository>(
+      CONTAINER_TYPES.PlayerGameStatsRepository
+    );
+  });
+
+  afterAll(async () => {
+    try {
+      await testEnv.teardown();
+      if (cleanup) await cleanup();
+    } catch (err) {
+      console.error("Error during teardown:", err);
+    }
+  });
+
+  beforeEach(async () => {
+    // Clear Redis before each test
+    const redisClient = RedisConfig.getClient();
+    const keys = await redisClient.keys("*");
+    if (keys.length > 0) {
+      await redisClient.del(...keys);
+    }
+
+    const keysUpdated = await redisClient.keys("*");
+    if (keysUpdated.length > 0) {
+      throw new Error(`Redis keys not cleared before test: ${keysUpdated}`);
+    }
+  });
+
+  /**
+   * Helper to wait for a player to be kicked by listening to PLAYER_KICKED event
+   */
+  async function waitForPlayerKick(
+    socket: GameClientSocket,
+    playerId: number,
+    timeout: number = 5000
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        socket.removeListener(SocketIOGameEvents.PLAYER_KICKED, handler);
+        reject(new Error("Timeout waiting for PLAYER_KICKED event"));
+      }, timeout);
+
+      const handler = (data: any) => {
+        if (data.playerId === playerId) {
+          clearTimeout(timeoutId);
+          socket.removeListener(SocketIOGameEvents.PLAYER_KICKED, handler);
+          resolve();
+        }
+      };
+
+      socket.on(SocketIOGameEvents.PLAYER_KICKED, handler);
+    });
+  }
+
+  /**
+   * Helper to wait for a player role change by listening to PLAYER_ROLE_CHANGE event
+   */
+  async function waitForPlayerRoleChange(
+    socket: GameClientSocket,
+    playerId: number,
+    expectedRole: PlayerRole,
+    timeout: number = 5000
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        socket.removeListener(SocketIOGameEvents.PLAYER_ROLE_CHANGE, handler);
+        reject(new Error("Timeout waiting for PLAYER_ROLE_CHANGE event"));
+      }, timeout);
+
+      const handler = (data: any) => {
+        if (data.playerId === playerId && data.newRole === expectedRole) {
+          clearTimeout(timeoutId);
+          socket.removeListener(SocketIOGameEvents.PLAYER_ROLE_CHANGE, handler);
+          resolve();
+        }
+      };
+
+      socket.on(SocketIOGameEvents.PLAYER_ROLE_CHANGE, handler);
+    });
+  }
+
+  describe("Player Session Initialization", () => {
+    it("should initialize player session in Redis when player joins game", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+
+        // Verify session was created in Redis
+        const sessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+
+        expect(sessionData).toBeTruthy();
+        expect(sessionData!.gameId).toBe(gameId);
+        expect(sessionData!.userId).toBe(playerId.toString());
+        expect(sessionData!.joinedAt).toBeTruthy();
+        expect(sessionData!.leftAt).toBe(""); // Redis stores null as empty string
+        expect(sessionData!.currentScore).toBe("0");
+        expect(sessionData!.questionsAnswered).toBe("0");
+        expect(sessionData!.correctAnswers).toBe("0");
+        expect(sessionData!.wrongAnswers).toBe("0");
+
+        // Verify joinedAt is a recent timestamp
+        const joinedAt = new Date(sessionData!.joinedAt);
+        const now = new Date();
+        const timeDiff = now.getTime() - joinedAt.getTime();
+        expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should not initialize session for spectators", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 0, 1);
+
+      try {
+        const gameId = setup.gameId;
+
+        // Since we don't have spectator user info in setup, create one manually
+        const { user: spectatorUser } = await utils.createGameClient(
+          app,
+          userRepo
+        );
+
+        // Verify no session was created for spectator
+        const sessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          spectatorUser.id
+        );
+
+        expect(sessionData).toBeNull();
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+
+  describe("Player Session Finalization", () => {
+    it("should update leftAt timestamp when player leaves game", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const playerSocket = setup.playerSockets[0];
+
+        // Verify initial session has no leftAt
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData!.leftAt).toBe("");
+
+        // Leave the game (this already waits for the LEAVE event)
+        await utils.leaveGame(playerSocket);
+
+        // Verify session now has leftAt timestamp
+        const finalSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(finalSessionData).toBeTruthy();
+        expect(finalSessionData!.leftAt).not.toBe("");
+
+        // Verify leftAt is a recent timestamp
+        const leftAt = new Date(finalSessionData!.leftAt);
+        const now = new Date();
+        const timeDiff = now.getTime() - leftAt.getTime();
+        expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should update leftAt timestamp when player is kicked", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const showmanSocket = setup.showmanSocket;
+
+        // Verify initial session has no leftAt
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData!.leftAt).toBe("");
+
+        // Wait for the kick event to be processed and then check stats
+        const kickPromise = waitForPlayerKick(showmanSocket, playerId);
+
+        // Kick the player
+        showmanSocket.emit(SocketIOGameEvents.PLAYER_KICKED, {
+          playerId: playerId,
+        });
+
+        // Wait for the kick event to be processed
+        await kickPromise;
+
+        // Verify session now has leftAt timestamp
+        const finalSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(finalSessionData).toBeTruthy();
+        expect(finalSessionData!.leftAt).not.toBe("");
+
+        // Verify leftAt is a recent timestamp
+        const leftAt = new Date(finalSessionData!.leftAt);
+        const now = new Date();
+        const timeDiff = now.getTime() - leftAt.getTime();
+        expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should update leftAt timestamp when player role changes from player to spectator", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const showmanSocket = setup.showmanSocket;
+
+        // Verify initial session has no leftAt
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData!.leftAt).toBe("");
+
+        // Wait for the role change event to be processed
+        const roleChangePromise = waitForPlayerRoleChange(
+          showmanSocket,
+          playerId,
+          PlayerRole.SPECTATOR
+        );
+
+        // Change player role to spectator
+        showmanSocket.emit(SocketIOGameEvents.PLAYER_ROLE_CHANGE, {
+          newRole: PlayerRole.SPECTATOR,
+          playerId: playerId,
+        });
+
+        // Wait for the role change event to be processed
+        await roleChangePromise;
+
+        // Verify session now has leftAt timestamp
+        const finalSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(finalSessionData).toBeTruthy();
+        expect(finalSessionData!.leftAt).not.toBe("");
+
+        // Verify leftAt is a recent timestamp
+        const leftAt = new Date(finalSessionData!.leftAt);
+        const now = new Date();
+        const timeDiff = now.getTime() - leftAt.getTime();
+        expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+
+  describe("Full Player Session Lifecycle", () => {
+    it("should track complete player session from join to leave", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const playerSocket = setup.playerSockets[0];
+
+        // Step 1: Verify session initialization
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData).toBeTruthy();
+        expect(initialSessionData!.gameId).toBe(gameId);
+        expect(initialSessionData!.userId).toBe(playerId.toString());
+        expect(initialSessionData!.joinedAt).toBeTruthy();
+        expect(initialSessionData!.leftAt).toBe("");
+
+        const joinTime = new Date(initialSessionData!.joinedAt);
+
+        // Step 2: Leave the game (this already waits for the LEAVE event)
+        await utils.leaveGame(playerSocket);
+
+        // Step 3: Verify session finalization
+        const finalSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(finalSessionData).toBeTruthy();
+        expect(finalSessionData!.leftAt).not.toBe("");
+
+        const leaveTime = new Date(finalSessionData!.leftAt);
+
+        // Step 6: Verify temporal consistency - allow for timing being very close or equal
+        expect(leaveTime.getTime()).toBeGreaterThanOrEqual(joinTime.getTime());
+
+        // Step 7: Calculate session duration (allow for very fast operations)
+        const sessionDuration = leaveTime.getTime() - joinTime.getTime();
+        expect(sessionDuration).toBeGreaterThanOrEqual(0); // Allow same timestamp for very fast operations
+        expect(sessionDuration).toBeLessThan(1000); // Less than 1 second for this test
+
+        // Step 8: Verify all session data is preserved
+        expect(finalSessionData!.gameId).toBe(gameId);
+        expect(finalSessionData!.userId).toBe(playerId.toString());
+        expect(finalSessionData!.currentScore).toBe("0");
+        expect(finalSessionData!.questionsAnswered).toBe("0");
+        expect(finalSessionData!.correctAnswers).toBe("0");
+        expect(finalSessionData!.wrongAnswers).toBe("0");
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should handle multiple players with independent sessions", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 2, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const player1Id = setup.playerUsers[0].id;
+        const player2Id = setup.playerUsers[1].id;
+        const player1Socket = setup.playerSockets[0];
+
+        // Verify both players have sessions
+        const player1SessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          player1Id
+        );
+        const player2SessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          player2Id
+        );
+
+        expect(player1SessionData).toBeTruthy();
+        expect(player2SessionData).toBeTruthy();
+        expect(player1SessionData!.userId).toBe(player1Id.toString());
+        expect(player2SessionData!.userId).toBe(player2Id.toString());
+
+        // Player 1 leaves (this already waits for the LEAVE event)
+        await utils.leaveGame(player1Socket);
+
+        // Verify player 1 session is finalized but player 2 session is still active
+        const finalPlayer1SessionData =
+          await playerGameStatsRepository.getStats(gameId, player1Id);
+        const continuedPlayer2SessionData =
+          await playerGameStatsRepository.getStats(gameId, player2Id);
+
+        expect(finalPlayer1SessionData!.leftAt).not.toBe("");
+        expect(continuedPlayer2SessionData!.leftAt).toBe("");
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+
+  describe("Player Session Rejoin and Role Change Clearing", () => {
+    it("should clear leftAt timestamp when player rejoins after leaving", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const playerSocket = setup.playerSockets[0];
+
+        // Verify initial session has no leftAt
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData!.leftAt).toBe("");
+
+        // Player leaves
+        await utils.leaveGame(playerSocket);
+
+        // Verify leftAt is set
+        const leftSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(leftSessionData!.leftAt).not.toBe("");
+
+        // Player rejoins the same game as player role
+        await utils.joinGame(playerSocket, gameId, PlayerRole.PLAYER);
+
+        // Verify leftAt is cleared after rejoin
+        const rejoinedSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(rejoinedSessionData!.leftAt).toBe("");
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+
+    it("should clear leftAt when player changes back to PLAYER after being spectator", async () => {
+      const setup = await utils.setupGameTestEnvironment(userRepo, app, 1, 0);
+
+      try {
+        const gameId = setup.gameId;
+        const playerId = setup.playerUsers[0].id;
+        const showmanSocket = setup.showmanSocket;
+
+        // Verify initial session has no leftAt
+        const initialSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(initialSessionData!.leftAt).toBe("");
+
+        // Change player role to spectator (this should set leftAt)
+        const roleChangeToSpectatorPromise = waitForPlayerRoleChange(
+          showmanSocket,
+          playerId,
+          PlayerRole.SPECTATOR
+        );
+
+        showmanSocket.emit(SocketIOGameEvents.PLAYER_ROLE_CHANGE, {
+          newRole: PlayerRole.SPECTATOR,
+          playerId: playerId,
+        });
+
+        await roleChangeToSpectatorPromise;
+
+        // Verify leftAt is now set (because they are no longer a player)
+        const spectatorSessionData = await playerGameStatsRepository.getStats(
+          gameId,
+          playerId
+        );
+        expect(spectatorSessionData!.leftAt).not.toBe("");
+
+        // Change back to player role (this should clear leftAt)
+        const roleChangeToPlayerPromise = waitForPlayerRoleChange(
+          showmanSocket,
+          playerId,
+          PlayerRole.PLAYER
+        );
+
+        showmanSocket.emit(SocketIOGameEvents.PLAYER_ROLE_CHANGE, {
+          newRole: PlayerRole.PLAYER,
+          playerId: playerId,
+        });
+
+        await roleChangeToPlayerPromise;
+
+        // Verify leftAt is cleared after becoming player again
+        const backToPlayerSessionData =
+          await playerGameStatsRepository.getStats(gameId, playerId);
+        expect(backToPlayerSessionData!.leftAt).toBe("");
+      } finally {
+        await utils.cleanupGameClients(setup);
+      }
+    });
+  });
+});

--- a/server/tests/utils/PackageUtils.ts
+++ b/server/tests/utils/PackageUtils.ts
@@ -16,7 +16,8 @@ export class PackageUtils {
 
   public createTestPackageData(
     author: ShortUserInfo,
-    includeFinalRound: boolean = true
+    includeFinalRound: boolean = true,
+    additionalSimpleQuestions: number = 0
   ): PackageDTO {
     const rounds = [
       {
@@ -220,6 +221,21 @@ export class PackageUtils {
           },
         ],
       });
+    }
+
+    if (additionalSimpleQuestions > 0) {
+      rounds[0].themes[0].questions.push(
+        ...(Array.from({ length: additionalSimpleQuestions }, (_, index) => ({
+          type: PackageQuestionType.SIMPLE,
+          subType: PackageQuestionSubType.SIMPLE,
+          order: rounds[0].themes[0].questions.length + index,
+          price: 100 + index * 50,
+          text: `Additional simple question ${index + 1}`,
+          answerText: `Additional answer ${index + 1}`,
+          answerDelay: 5000,
+          isHidden: false,
+        })) satisfies PackageQuestionDTO[])
+      );
     }
 
     return {

--- a/server/tests/utils/utils.ts
+++ b/server/tests/utils/utils.ts
@@ -12,6 +12,7 @@ import { PackageRound } from "infrastructure/database/models/package/PackageRoun
 import { PackageTag } from "infrastructure/database/models/package/PackageTag";
 import { PackageTheme } from "infrastructure/database/models/package/PackageTheme";
 import { Permission } from "infrastructure/database/models/Permission";
+import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
 import { User } from "infrastructure/database/models/User";
 
 export function setTestEnvDefaults() {
@@ -20,7 +21,8 @@ export function setTestEnvDefaults() {
   process.env.DB_TYPE = "pg";
   process.env.DB_NAME = "test_db";
   process.env.DB_USER = "postgres";
-  process.env.DB_PASS = "postgres";
+  // process.env.DB_PASS = "postgres";
+  process.env.DB_PASS = "Asdf1234!";
   process.env.DB_HOST = "localhost";
   process.env.DB_PORT = "5432";
   process.env.DB_LOGGER = "false";
@@ -66,6 +68,7 @@ export function createTestAppDataSource() {
       PackageTag,
       PackageTheme,
       PackageQuestionChoiceAnswer,
+      GameStatistics,
     ],
     migrations: [],
     synchronize: true,

--- a/server/tests/utils/utils.ts
+++ b/server/tests/utils/utils.ts
@@ -13,6 +13,7 @@ import { PackageTag } from "infrastructure/database/models/package/PackageTag";
 import { PackageTheme } from "infrastructure/database/models/package/PackageTheme";
 import { Permission } from "infrastructure/database/models/Permission";
 import { GameStatistics } from "infrastructure/database/models/statistics/GameStatistics";
+import { PlayerGameStats } from "infrastructure/database/models/statistics/PlayerGameStats";
 import { User } from "infrastructure/database/models/User";
 
 export function setTestEnvDefaults() {
@@ -69,6 +70,7 @@ export function createTestAppDataSource() {
       PackageTheme,
       PackageQuestionChoiceAnswer,
       GameStatistics,
+      PlayerGameStats,
     ],
     migrations: [],
     synchronize: true,


### PR DESCRIPTION
Collect game and players statistics when game is ended. Currently it's all done in a monolith repository without external micro service and without doing DB calls in separate thread, but can be improved later ofc